### PR TITLE
Added command line option for mongo db

### DIFF
--- a/src/services/index.js
+++ b/src/services/index.js
@@ -24,7 +24,7 @@ const mongoose = require('mongoose');
 module.exports = function () {
     const app = this;
 
-    mongoose.connect(app.get('mongodb'), {user:process.env.DB_USERNAME, pass:process.env.DB_PASSWORD});
+    mongoose.connect(process.env.DB_URL || app.get('mongodb'), {user:process.env.DB_USERNAME, pass:process.env.DB_PASSWORD});
     mongoose.Promise = global.Promise;
 
     app.configure(authentication);


### PR DESCRIPTION
Problem: When I started with npm install, the following error occured:
    MongoError: failed to connect to server [localhost:27017] on first connect [MongoError: getaddrinfo EAI_AGAIN localhost:27017]
This is the same error as in http://stackoverflow.com/questions/41318354/mongodb-failed-to-connect-to-server-on-first-connect

Cause: The name 'localhost' can not be resolved to 127.0.0.1.
Solution: As pointed out in https://github.com/Automattic/mongoose/issues/3049#issuecomment-108620496
the solution is to set the host of mongodb to 127.0.0.1

Implementation: This is implemented by allowing a environment variable to set the mongodb host.
The variable is optional and is named DB_URL as it also includes the data base.