### PR TITLE
restrict access to accounts

### DIFF
--- a/src/services/account/hooks/index.js
+++ b/src/services/account/hooks/index.js
@@ -76,10 +76,21 @@ const checkUnique = (hook) => {
 		});
 };
 
+const restrictAccess = (hook) => {
+	let queries = hook.params.query;
+
+	return new Promise ((resolve, reject) => {
+		if (!queries.username)
+			return reject(new errors.NotAuthenticated("No auth token"));
+		else
+			return resolve();
+	});
+};
+
 exports.before = {
 	// find, get and create cannot be protected by auth.hooks.authenticate('jwt')
 	// otherwise we cannot get the accounts required for login
-	find: [],
+	find: [restrictAccess],
 	get: [],
 	create: [
 		validateCredentials,

--- a/src/services/lesson/hooks/index.js
+++ b/src/services/lesson/hooks/index.js
@@ -5,7 +5,7 @@ const hooks = require('feathers-hooks');
 const auth = require('feathers-authentication');
 
 exports.before = {
-	all: [(hook) => {
+	all: [auth.hooks.authenticate('jwt'), (hook) => {
 		if(hook.data) {
 			hook.data.contents = (hook.data.contents || []).map((item) => {
 				switch (item.component) {

--- a/src/services/passwordRecovery/hooks/index.js
+++ b/src/services/passwordRecovery/hooks/index.js
@@ -24,13 +24,13 @@ const hashId = (hook) => {
 
 exports.before = {
 	all: [],
-	find: [],
+	find: [auth.hooks.authenticate('jwt')],
 	get: [],
 	create: [hashId,
 		local.hooks.hashPassword({passwordField: 'password'})],
-	update: [],
-	patch: [],
-	remove: []
+	update: [auth.hooks.authenticate('jwt')],
+	patch: [auth.hooks.authenticate('jwt')],
+	remove: [auth.hooks.authenticate('jwt')]
 };
 
 exports.after = {


### PR DESCRIPTION
can't restrict the access further without an api key or any other security...
tried stripping the password or any other information, but those are needed by the feathers-authentication-local for verification purposes.

A proper solution could be to write an own verifier, which does not rely on the account service, but uses mongoosejs to directly talk to the db.