### PR TITLE
added generic hook for school check

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -232,3 +232,20 @@ exports.denyIfNotCurrentSchool = ({errorMessage = 'Die angefragte Ressource gehÃ
 			return hook;
 		});
 	};
+
+exports.checkSchoolOwnership = hook => {
+	let userId = hook.params.account.userId;
+	let objectId = hook.id;
+	let service = hook.path;
+
+	let genericService = hook.app.service(service);
+	let userService = hook.app.service('users');
+
+	return Promise.all([userService.get(userId), genericService.get(objectId)])
+		.then(res => {
+			if (res[0].schoolId.equals(res[1].schoolId))
+				return hook;
+			else
+				throw new errors.Forbidden('You do not have valid permissions to access this.');
+		});
+};

--- a/src/services/helpdesk/hooks/index.js
+++ b/src/services/helpdesk/hooks/index.js
@@ -11,7 +11,7 @@ exports.before = {
 	create: [globalHooks.hasPermission('HELPDESK_CREATE')],
 	update: [globalHooks.hasPermission('HELPDESK_EDIT')],
 	patch: [globalHooks.hasPermission('HELPDESK_EDIT'),globalHooks.permitGroupOperation],
-	remove: [globalHooks.hasPermission('HELPDESK_CREATE'),globalHooks.permitGroupOperation]
+	remove: [globalHooks.hasPermission('HELPDESK_CREATE'),globalHooks.permitGroupOperation, globalHooks.checkSchoolOwnership]
 };
 
 exports.after = {

--- a/src/services/helpdesk/hooks/index.js
+++ b/src/services/helpdesk/hooks/index.js
@@ -11,7 +11,7 @@ exports.before = {
 	create: [globalHooks.hasPermission('HELPDESK_CREATE')],
 	update: [globalHooks.hasPermission('HELPDESK_EDIT')],
 	patch: [globalHooks.hasPermission('HELPDESK_EDIT'),globalHooks.permitGroupOperation],
-	remove: [globalHooks.hasPermission('HELPDESK_CREATE'),globalHooks.permitGroupOperation, globalHooks.checkSchoolOwnership]
+	remove: [globalHooks.hasPermission('HELPDESK_CREATE'),globalHooks.permitGroupOperation, globalHooks.ifNotLocal(globalHooks.checkSchoolOwnership)]
 };
 
 exports.after = {

--- a/src/services/news/hooks/index.js
+++ b/src/services/news/hooks/index.js
@@ -25,7 +25,7 @@ exports.before = {
 	create: [globalHooks.hasPermission('NEWS_CREATE')],
 	update: [globalHooks.hasPermission('NEWS_EDIT'), restrictToCurrentSchool],
 	patch: [globalHooks.hasPermission('NEWS_EDIT'), restrictToCurrentSchool,globalHooks.permitGroupOperation],
-	remove: [globalHooks.hasPermission('NEWS_CREATE'), restrictToCurrentSchool,globalHooks.permitGroupOperation,deleteNewsHistory, globalHooks.checkSchoolOwnership]
+	remove: [globalHooks.hasPermission('NEWS_CREATE'), restrictToCurrentSchool,globalHooks.permitGroupOperation,deleteNewsHistory, globalHooks.ifNotLocal(globalHooks.checkSchoolOwnership)]
 };
 
 exports.after = {

--- a/src/services/news/hooks/index.js
+++ b/src/services/news/hooks/index.js
@@ -25,7 +25,7 @@ exports.before = {
 	create: [globalHooks.hasPermission('NEWS_CREATE')],
 	update: [globalHooks.hasPermission('NEWS_EDIT'), restrictToCurrentSchool],
 	patch: [globalHooks.hasPermission('NEWS_EDIT'), restrictToCurrentSchool,globalHooks.permitGroupOperation],
-	remove: [globalHooks.hasPermission('NEWS_CREATE'), restrictToCurrentSchool,globalHooks.permitGroupOperation,deleteNewsHistory]
+	remove: [globalHooks.hasPermission('NEWS_CREATE'), restrictToCurrentSchool,globalHooks.permitGroupOperation,deleteNewsHistory, globalHooks.checkSchoolOwnership]
 };
 
 exports.after = {


### PR DESCRIPTION
checks in a remove request whether the schoolId of object and requesting user are equal.
Can also be used for any other hook type that supports `/@id` and has a schoolId or just use restrictToCurrentSchool.
Can also be used for any service that has a schoolId in it, just tested it with news and helpdesk service.