### PR TITLE
no double account creation

### DIFF
--- a/src/services/account/hooks/index.js
+++ b/src/services/account/hooks/index.js
@@ -110,12 +110,23 @@ const restrictAccess = (hook) => {
 	});
 };
 
+const checkExistence = (hook) => {
+	let accountService = hook.service;
+	const {userId} = hook.data;
+	return accountService.find({ query: {userId}})
+		.then(result => {
+			if(result.length > 0) return Promise.reject(new errors.BadRequest('Der Account existiert bereits!'));
+			return Promise.resolve(hook);
+		});
+};
+
 exports.before = {
 	// find, get and create cannot be protected by auth.hooks.authenticate('jwt')
 	// otherwise we cannot get the accounts required for login
 	find: [restrictAccess],
 	get: [],
 	create: [
+		checkExistence,
 		validateCredentials,
 		trimPassword,
 		local.hooks.hashPassword({ passwordField: 'password' }),

--- a/test/services/account/index.test.js
+++ b/test/services/account/index.test.js
@@ -53,6 +53,16 @@ describe('account service', function () {
 
 	});
 
+	it('fail to patch userId', () => {
+		const accountService = app.service('/accounts');
+
+		return accountService.patch("0000d213816abba584714caa", { userId: "0000d186816abba584714c5e" })
+			.catch(exception => {
+				assert.equal(exception.message, 'Die userId kann nicht geändert werden.');
+				assert.equal(exception.code, 403);
+			});
+	});
+
 	it('not able to access whole find', () => {
 		const accountService = app.service('/accounts');
 

--- a/test/services/account/index.test.js
+++ b/test/services/account/index.test.js
@@ -2,6 +2,8 @@
 
 const assert = require('assert');
 const app = require('../../../src/app');
+const accountService = app.service('/accounts');
+const userService = app.service('/users');
 
 describe('account service', function () {
 	it('registered the accounts service', () => {
@@ -9,8 +11,6 @@ describe('account service', function () {
 	});
 
 	it('the account already exists', () => {
-		const accountService = app.service('/accounts');
-
 		let accountObject = {
 			username: "max" + Date.now() + "@mHuEsLtIeXrmann.de",
 			password: "ca4t9fsfr3dsd",
@@ -24,9 +24,6 @@ describe('account service', function () {
 	});
 
 	it('create an account', () => {
-		const userService = app.service('/users');
-		const accountService = app.service('/accounts');
-
 		let userObject = {
 			firstName: "Max",
 			lastName: "Mustermann",
@@ -54,8 +51,6 @@ describe('account service', function () {
 	});
 
 	it('fail to patch userId', () => {
-		const accountService = app.service('/accounts');
-
 		return accountService.patch("0000d213816abba584714caa", { userId: "0000d186816abba584714c5e" })
 			.catch(exception => {
 				assert.equal(exception.message, 'Die userId kann nicht geändert werden.');
@@ -64,8 +59,6 @@ describe('account service', function () {
 	});
 
 	it('not able to access whole find', () => {
-		const accountService = app.service('/accounts');
-
 		return accountService.find()
 			.catch(exception => {
 				assert.equal(exception.message, 'Cannot read property \'username\' of undefined');

--- a/test/services/account/index.test.js
+++ b/test/services/account/index.test.js
@@ -7,4 +7,28 @@ describe('account service', function () {
 	it('registered the accounts service', () => {
 		assert.ok(app.service('accounts'));
 	});
+
+	it('the account already exists', () => {
+		const accountService = app.service('/accounts');
+
+		let accountObject = {
+			username: "max" + Date.now() + "@mHuEsLtIeXrmann.de",
+			password: "ca4t9fsfr3dsd",
+			userId: "0000d213816abba584714c0a"
+		};
+
+		return accountService.create(accountObject)
+			.catch(exception => {
+				assert.equal(exception.message, 'Der Account existiert bereits!');
+			});
+	});
+
+	it('not able to access whole find', () => {
+		const accountService = app.service('/accounts');
+
+		return accountService.find()
+			.catch(exception => {
+				assert.equal(exception.message, 'Cannot read property \'username\' of undefined');
+			});
+	});
 });

--- a/test/services/account/index.test.js
+++ b/test/services/account/index.test.js
@@ -23,6 +23,36 @@ describe('account service', function () {
 			});
 	});
 
+	it('create an account', () => {
+		const userService = app.service('/users');
+		const accountService = app.service('/accounts');
+
+		let userObject = {
+			firstName: "Max",
+			lastName: "Mustermann",
+			email: "max" + Date.now() + "@mustermann.de",
+			schoolId: "584ad186816abba584714c94"
+		};
+
+		return userService.create(userObject)
+			.then(user => {
+				let accountObject = {
+					username: "max" + Date.now() + "@mHuEsLtIeXrmann.de",
+					password: "ca4t9fsfr3dsd",
+					userId: user._id
+				};
+
+				assert.equal(user.lastName, userObject.lastName);
+
+				return accountService.create(accountObject)
+					.then(account => {
+						assert.ok(account);
+						assert.equal(account.username, accountObject.username.toLowerCase());
+					});
+			});
+
+	});
+
 	it('not able to access whole find', () => {
 		const accountService = app.service('/accounts');
 


### PR DESCRIPTION
As https://github.com/schul-cloud/schulcloud-server/pull/297 is currently stuck in bureaucracy, I wanted to at least address the problem with the possibility to create multiple accounts with one userId.

Deals to a limited extend with SC-149