### PR TITLE
SC-359: Add pseudonym service and originTool to ltiTool schema

### DIFF
--- a/src/services/index.js
+++ b/src/services/index.js
@@ -24,6 +24,7 @@ const releases = require('./releases');
 const helpdesk = require('./helpdesk');
 const statistic = require('./statistic');
 const socket = require('./socket');
+const pseudonym = require("./pseudonym");
 
 const mongoose = require('mongoose');
 
@@ -57,4 +58,5 @@ module.exports = function () {
 	app.configure(helpdesk);
 	app.configure(statistic);
 	app.configure(socket);
+	app.configure(pseudonym);
 };

--- a/src/services/ltiTool/model.js
+++ b/src/services/ltiTool/model.js
@@ -8,7 +8,7 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const ltiToolSchema = new Schema({
+const ltiTool = new Schema({
   name: { type: String },
   url: { type: String, required: true },
   key: { type: String, required: true },
@@ -23,9 +23,10 @@ const ltiToolSchema = new Schema({
   isTemplate: {type: Boolean},
   isLocal: {type: Boolean},
   createdAt: { type: Date, 'default': Date.now },
-  updatedAt: { type: Date, 'default': Date.now }
+  updatedAt: { type: Date, 'default': Date.now },
+  originTool: { type: Schema.Types.ObjectId, ref: 'ltiTool'},
 });
 
-const ltiToolModel = mongoose.model('ltiTool', ltiToolSchema);
+const ltiToolModel = mongoose.model('ltiTool', ltiTool);
 
 module.exports = ltiToolModel;

--- a/src/services/pseudonym/hooks/index.js
+++ b/src/services/pseudonym/hooks/index.js
@@ -1,0 +1,81 @@
+'use strict';
+const auth = require('feathers-authentication');
+const globalHooks = require('../../../hooks');
+const errors = require('feathers-errors');
+const toArray = data => (Array.isArray(data) ? data	: [data]);
+
+// rewrite tool id if there is a origin tool (content-specific pseudonym)
+const replaceToolWithOrigin = hook => {
+	if (!hook.params.query.toolId) return hook;
+	return hook.app.service('ltiTools').get(hook.params.query.toolId).then(tool => {
+		hook.params.query.toolId = tool.originTool || hook.params.query.toolId;
+		return hook;
+	});
+};
+
+// looks for user and tool combinations that aren't existing and creates them
+const createMissingPseudonyms = hook => {
+	if(!hook.params.query.toolId || !hook.params.query.userId) return hook;
+	const toolIds = toArray(hook.params.query.toolId);
+	const userIds = toArray(hook.params.query.userId);
+	let missingPseudonyms = [];
+	for (let userId of userIds) {
+		for (let toolId of toolIds) {
+			if (!hook.result.data.find(entry => (
+					entry.userId.toString() == userId &&
+					entry.toolId.toString() == toolId))) {
+				missingPseudonyms.push({userId, toolId});
+			}
+		}
+	}
+	if (!missingPseudonyms.length) return hook;
+	return hook.app.service('pseudonym')
+		.create(missingPseudonyms)
+		.then(results => {
+			hook.result.data = hook.result.data.concat(results);
+			return hook;
+		});
+};
+
+// restricts the return pseudonyms to the users the current user is allowed to retrieve
+const filterValidUsers = context => {
+	let validUserIds = [context.params.account.userId];
+	return context.app.service('courses').find({
+		query: {
+			teacherIds: context.params.account.userId,
+			$populate: 'classIds'
+		}
+	}).then(courses => {
+		for (let course of courses.data) {
+			validUserIds = validUserIds.concat(course.userIds);
+			for (let _class of course.classIds) {
+				validUserIds = validUserIds.concat(_class.userIds);
+			}
+		}
+		validUserIds = validUserIds.map(element => element.toString());
+		context.result.data = context.result.data.filter(pseudonym =>
+			validUserIds.includes(pseudonym.userId._id.toString())
+		);
+		return context;
+	});
+};
+
+exports.before = {
+	all: [auth.hooks.authenticate('jwt')],
+	find: [replaceToolWithOrigin],
+	get: [_ => {throw new errors.MethodNotAllowed();}],
+	create: [globalHooks.ifNotLocal(_ => {throw new errors.MethodNotAllowed();})],
+	update: [_ => {throw new errors.MethodNotAllowed();}],
+	patch: [_ => {throw new errors.MethodNotAllowed();}],
+	remove: [_ => {throw new errors.MethodNotAllowed();}]
+};
+
+exports.after = {
+	all: [],
+	find: [createMissingPseudonyms, globalHooks.ifNotLocal(filterValidUsers)],
+	get: [],
+	create: [],
+	update: [],
+	patch: [],
+	remove: []
+};

--- a/src/services/pseudonym/index.js
+++ b/src/services/pseudonym/index.js
@@ -1,0 +1,21 @@
+'use strict';
+const service = require('feathers-mongoose');
+const Pseudonym = require('./model');
+const hooks = require('./hooks');
+
+module.exports = function() {
+	const app = this;
+	const options = {
+		Model: Pseudonym,
+		paginate: {
+			default: 1000,
+			max: 1000
+		}
+	};
+
+	app.use('/pseudonym', service(options));
+
+	const pseudonymService = app.service('/pseudonym');
+	pseudonymService.before(hooks.before);
+	pseudonymService.after(hooks.after);
+};

--- a/src/services/pseudonym/model.js
+++ b/src/services/pseudonym/model.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+const idValidator = require('mongoose-id-validator');
+const uuid = require("uuid/v4");
+
+const Pseudonym = new Schema({
+	userId: {type: Schema.Types.ObjectId, ref: 'user'},
+	toolId: {type: Schema.Types.ObjectId, ref: 'ltiTool'},
+	token : {type: String, required: true, default: uuid},
+}, {
+	timestamps: true
+});
+
+Pseudonym.plugin(idValidator);
+
+module.exports = mongoose.model("Pseudonym", Pseudonym);

--- a/test/services/pseudonym/index.test.js
+++ b/test/services/pseudonym/index.test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const assert = require('assert');
+const app = require('../../../src/app');
+const chai = require('chai');
+const pseudonymService = app.service('pseudonym');
+const toolService = app.service('ltiTools');
+const expect = chai.expect;
+
+describe('pseudonym service', function() {
+	this.timeout(10000);
+
+	const testTool1 = {
+		"_id": "5a79cb15c3874f9aea14daa5",
+		"name": "test1",
+		"url": "https://tool.com?pseudonym={PSEUDONYM}",
+		"isLocal": true,
+		"isTemplate": true,
+		"resource_link_id": 1,
+		"lti_version": "1p0",
+		"lti_message_type": "basic-start-request",
+		"secret": "1",
+		"key": "1",
+	};
+	const testTool2 = {
+		"_id": "5a79cb15c3874f9aea14daa6",
+		"originTool": '5a79cb15c3874f9aea14daa5',
+		"name": "test2",
+		"url": "https://tool.com?pseudonym={PSEUDONYM}",
+		"isLocal": true,
+		"resource_link_id": 1,
+		"lti_version": "1p0",
+		"lti_message_type": "basic-start-request",
+		"secret": "1",
+		"key": "1",
+	};
+
+	before(done => {
+		this.timeout(10000);
+		Promise.all([
+			toolService.create(testTool1),
+			toolService.create(testTool2)
+		]).then(results => {
+			done();
+		});
+	});
+
+	after(done => {
+		Promise.all([
+			toolService.remove(testTool1),
+			toolService.remove(testTool2)
+		]).then(results => {
+			done();
+		});
+	});
+
+	it('is registered', () => {
+		assert.ok(app.service('pseudonym'));
+	});
+
+	it("throws MethodNotAllowed on GET", () => {
+		return pseudonymService.get('5a79cb15c3874f9aea14daa6').then(_ => {
+			throw new Error('Was not supposed to succeed');
+		}).catch(err => {
+			assert(err.name, 'MethodNotAllowed');
+			assert(err.code, 405);
+		});
+	});
+
+	it("throws MethodNotAllowed on UPDATE", () => {
+		return pseudonymService.update('5a79cb15c3874f9aea14daa6', {}).then(_ => {
+			throw new Error('Was not supposed to succeed');
+		}).catch(err => {
+			assert(err.name, 'MethodNotAllowed');
+			assert(err.code, 405);
+		});
+	});
+
+	it("throws MethodNotAllowed on PATCH", () => {
+		return pseudonymService.patch('5a79cb15c3874f9aea14daa6', {}).then(_ => {
+			throw new Error('Was not supposed to succeed');
+		}).catch(err => {
+			assert(err.name, 'MethodNotAllowed');
+			assert(err.code, 405);
+		});
+	});
+
+	it("throws MethodNotAllowed on REMOVE", () => {
+		return pseudonymService.remove('5a79cb15c3874f9aea14daa6').then(_ => {
+			throw new Error('Was not supposed to succeed');
+		}).catch(err => {
+			assert(err.name, 'MethodNotAllowed');
+			assert(err.code, 405);
+		});
+	});
+
+	let pseudonym = '';
+	it("creates missing pseudonym on FIND for derived tool", () => {
+		return pseudonymService.find({
+			query: {
+				userId: '59ad4c412b442b7f81810285',
+				toolId: testTool2._id
+			}
+		}).then(result => {
+			pseudonym = result.data[0].token;
+			expect(result.data[0].token).to.be.a('String');
+		});
+	});
+
+	it("returns existing pseudonym on FIND for derived tool", () => {
+		return pseudonymService.find({
+			query: {
+				userId: '59ad4c412b442b7f81810285',
+				toolId: testTool2._id
+			}
+		}).then(result => {
+			expect(result.data[0].token).to.eql(pseudonym);
+		});
+	});
+
+	it("returns existing pseudonym on FIND for origin tool", () => {
+		return pseudonymService.find({
+			query: {
+				userId: '59ad4c412b442b7f81810285',
+				toolId: testTool1._id
+			}
+		}).then(result => {
+			expect(result.data[0].token).to.eql(pseudonym);
+		});
+	});
+
+	let pseudonyms = [];
+	it("creates missing pseudonyms on FIND with multiple users", () => {
+		return pseudonymService.find({
+			query: {
+				userId: ['599ec1688e4e364ec18ff46e',
+					'599ec14d8e4e364ec18ff46d'],
+				toolId: testTool1._id
+			}
+		}).then(result => {
+			pseudonyms = result.data.map(pseudonym => pseudonym.token);
+			expect(result.data[0].token).to.be.a('String');
+		});
+	});
+
+	it("returns existing pseudonyms on FIND", () => {
+		return pseudonymService.find({
+			query: {
+				userId: ['599ec1688e4e364ec18ff46e',
+					'599ec14d8e4e364ec18ff46d'],
+				toolId: testTool1._id
+			}
+		}).then(result => {
+			expect(result.data[0].token).to.eql(pseudonyms[0]);
+			expect(result.data[1].token).to.eql(pseudonyms[1]);
+		});
+	});
+
+	it("doesn't create pseudonyms on FIND for missing users", () => {
+		return pseudonymService.find({
+			query: {
+				userId: '599ec1688e4e364ac18ff46e', // not existing userId
+				toolId: testTool1._id
+			}
+		}).then(result => {
+			throw new Error('Was not supposed to succeed');
+		}).catch(error => {
+			assert(error.name, 'NotFound');
+			assert(error.code, 404);
+		});
+	});
+
+	it("doesn't create pseudonyms on FIND for missing tool", () => {
+		return pseudonymService.find({
+			query: {
+				userId: '599ec1688e4e364ec18ff46e',
+				toolId: '599ec1688e4e364ec18ff46e' // not existing toolId
+			}
+		}).then(result => {
+			throw new Error('Was not supposed to succeed');
+		}).catch(error => {
+			assert(error.name, 'NotFound');
+			assert(error.code, 404);
+		});
+	});
+});


### PR DESCRIPTION
This adds the possibility to use pseudonyms for authentication against a content provider. It won't affect the current functionality.