### PR TITLE
aj/Authorization Header Fix

### DIFF
--- a/src/services/authentication/index.js
+++ b/src/services/authentication/index.js
@@ -69,14 +69,20 @@ module.exports = function() {
 		}
 	};
 
+	const authHeaderExtractor = function(req) {
+		let authHeader = req.headers.authorization;
+		if(!authHeader){ return undefined; }
+		return authHeader.replace("Bearer ", '');
+	}
+
 	const jwtConfig = {
 		name: 'jwt',
 		entity: 'account',
 		service: 'accounts',
 		header: 'Authorization',
 		jwtFromRequest: extractors.fromExtractors([
-			cookieExtractor, 
-			extractors.fromHeader("authorization")
+			cookieExtractor,
+			authHeaderExtractor
 		]),
 		secretOrKey: authenticationSecret
 	};


### PR DESCRIPTION
Anfragen mit Postman und jwt token funktionierten nicht, da im header for dem token "Bearer " angefügt wird. Soweit nicht so kritisch, jedoch produzieren manche Bibliotheken die wir einsetzen ebenfalls solche header mit "Bearer" vor dem token (bspw. Vue.js Einbindung von Jonas, Content Editor aus Seminar). Ich habe das jetzt so implementiert, dass es sowohl mit als auch ohne "Bearer " im Header funktioniert.