### PR TITLE
Simplify Seed Data

### DIFF
--- a/backup/setup/accounts.json
+++ b/backup/setup/accounts.json
@@ -1,18 +1,5 @@
 [{
 	"_id": {
-		"$oid": "0000d213816abba584714caa"
-	},
-	"username": "admin@schul-cloud.org",
-	"password": "$2a$10$xfKMgsqL1U0KTFYdJyJODeRQQDCn8/QSnC7nKIi1NDJh9Z3I5a7ZO",
-	"updatedAt" : { "$date": "2017-01-01T00:06:37.148Z" },
-	"createdAt" : { "$date": "2017-01-01T00:06:37.148Z" },
-	"userId": {
-		"$oid": "0000d213816abba584714c0a"
-	},
-	"__v": 0
-},
-{
-	"_id": {
 		"$oid": "0000d225816abba584714c9d"
 	},
 	"username": "schueler@schul-cloud.org",
@@ -29,7 +16,7 @@
 		"$oid": "0000d231816abba584714c9f"
 	},
 	"username": "lehrer@schul-cloud.org",
-	"password": "$2a$10$CHN6Qs2Igbn.s4BengUOfu9.0qVuy0uyTrzDDJszw9e1lBZwUFqeq",
+	"password": "$2a$10$EWASBNNdhOFse3zLkYhZ8uaRe5/mAqXyRRYRbMfDFYO/WQzYkJAsa",
 	"updatedAt" : { "$date": "2017-01-01T00:06:37.148Z" },
 	"createdAt" : { "$date": "2017-01-01T00:06:37.148Z" },
 	"userId": {
@@ -39,29 +26,29 @@
 },
 {
 	"_id": {
-		"$oid": "0000d231816abba584714c9b"
+		"$oid": "0000d213816abba584714caa"
 	},
-	"username": "jan.renz@schul-cloud.org",
-	"password": "$2a$10$CHN6Qs2Igbn.s4BengUOfu9.0qVuy0uyTrzDDJszw9e1lBZwUFqeq",
+	"username": "admin@schul-cloud.org",
+	"password": "$2a$10$EWASBNNdhOFse3zLkYhZ8uaRe5/mAqXyRRYRbMfDFYO/WQzYkJAsa",
 	"updatedAt" : { "$date": "2017-01-01T00:06:37.148Z" },
 	"createdAt" : { "$date": "2017-01-01T00:06:37.148Z" },
 	"userId": {
-		"$oid": "0000d213816abba584714c0b"
+		"$oid": "0000d213816abba584714c0a"
 	},
 	"__v": 0
 },
 {
-	"_id" : {
-		"$oid": "58b40279dac20e0645353e3b"
+	"_id": {
+		"$oid": "0000d231816abba584714c9a"
 	},
-	"userId" : {
-		"$oid": "58b40278dac20e0645353e3a"
-	},
-	"password" : "$2a$10$pF0q3WVaTn573pi8l.QrmuOjfQTZ7fQXBmPmMFLbILPLqN2mckUre",
+	"username": "superhero@schul-cloud.org",
+	"password": "$2a$10$EWASBNNdhOFse3zLkYhZ8uaRe5/mAqXyRRYRbMfDFYO/WQzYkJAsa",
 	"updatedAt" : { "$date": "2017-01-01T00:06:37.148Z" },
 	"createdAt" : { "$date": "2017-01-01T00:06:37.148Z" },
-	"username" : "maxim.asjoma@hpi.de",
-	"__v" : 0
+	"userId": {
+		"$oid": "0000d231816abba584714c9c"
+	},
+	"__v": 0
 },
 {
 	"_id" : { "$oid": "599ec1ea8e4e364ec18ff471"},
@@ -84,12 +71,38 @@
 	"__v" : 0
 },
 {
+	"_id": {
+		"$oid": "0000d231816abba584714c9b"
+	},
+	"username": "jan.renz@schul-cloud.org",
+	"password": "$2a$10$EWASBNNdhOFse3zLkYhZ8uaRe5/mAqXyRRYRbMfDFYO/WQzYkJAsa",
+	"updatedAt" : { "$date": "2017-01-01T00:06:37.148Z" },
+	"createdAt" : { "$date": "2017-01-01T00:06:37.148Z" },
+	"userId": {
+		"$oid": "0000d213816abba584714c0b"
+	},
+	"__v": 0
+},
+{
+	"_id" : {
+		"$oid": "58b40279dac20e0645353e3b"
+	},
+	"userId" : {
+		"$oid": "58b40278dac20e0645353e3a"
+	},
+	"password" : "$2a$10$EWASBNNdhOFse3zLkYhZ8uaRe5/mAqXyRRYRbMfDFYO/WQzYkJAsa",
+	"updatedAt" : { "$date": "2017-01-01T00:06:37.148Z" },
+	"createdAt" : { "$date": "2017-01-01T00:06:37.148Z" },
+	"username" : "maxim.asjoma@hpi.de",
+	"__v" : 0
+},
+{
 	"_id" : { "$oid": "59ad4c6e2b442b7f81810286"},
 	"updatedAt" : { "$date": "2017-09-04T12:51:58.490Z" },
 	"createdAt" : { "$date": "2017-09-04T12:51:58.490Z" },
 	"username" : "klara.fall@schul-cloud.org",
 	"userId" : { "$oid": "59ad4c412b442b7f81810285"},
-	"password" : "$2a$10$FUmM2S2iMVI3zQBQPrmJa.h85czeGB4lYuKA.//vWAMhHAeGScVmy",
+	"password" : "$2a$10$EWASBNNdhOFse3zLkYhZ8uaRe5/mAqXyRRYRbMfDFYO/WQzYkJAsa",
 	"activated" : true,
 	"__v" : 0
 },
@@ -99,7 +112,7 @@
 	"createdAt" : { "$date": "2017-09-05T11:26:06.761Z" },
 	"username" : "paula.meyer@schul-cloud.org",
 	"userId" : { "$oid": "59ae89b71f513506904e1cc9"},
-	"password" : "$2a$10$W3DBb3BL3HfZaZP2BAGcx.VNBKW12uYoTY0jdr0yekXji9i8QVK5e",
+	"password" : "$2a$10$EWASBNNdhOFse3zLkYhZ8uaRe5/mAqXyRRYRbMfDFYO/WQzYkJAsa",
 	"activated" : true,
 	"__v" : 0
 }

--- a/backup/setup/users.json
+++ b/backup/setup/users.json
@@ -82,6 +82,26 @@
 	]
 },
 {
+	"_id": {
+		"$oid": "0000d231816abba584714c9c"
+	},
+	"__v": 0,
+	"firstName": "Super",
+	"lastName": "Hero",
+	"updatedAt" : { "$date": "2017-01-01T00:06:37.148Z" },
+	"createdAt" : { "$date": "2017-01-01T00:06:37.148Z" },
+	"birthday": { "$date": "1977-01-01T11:25:43.556Z" },
+	"preferences": {"firstLogin": true},
+	"schoolId": {
+		"$oid": "0000d186816abba584714c5f"
+	},
+	"roles": [
+		{
+			"$oid": "0000d186816abba584714c95"
+		}
+	]
+},
+{
 	"_id" : {
 		"$oid": "58b40278dac20e0645353e3a"
 	},


### PR DESCRIPTION
Für den Einstieg in die Schul-Cloud hat sich bei der Einrichtung im BP herausgestellt, dass die verschiedenen Passwörter in den Backup Daten etwas verwirrend sind. Da die Daten sowieso nur lokal bei der Entwicklung verwendet werden würde ich vorschlagen das Standard Passwort in den Demodaten wie hier auf `schulcloud` zu ändern.

Zusätzlich habe ich einen weiteren Benutzer `Super` `Hero` (`superhero@schul-cloud.org`) eingeführt, welcher Zugang zum Superhero dashboard hat und somit für dieses als Testnutzer genutzt werden kann.

Feedback? und habe ich kritische Stellen vergessen, wo die neuen Passwörter noch eingetragen werden müssen?