### PR TITLE
Change File Creation for WOPI

### DIFF
--- a/src/services/fileStorage/proxy-service.js
+++ b/src/services/fileStorage/proxy-service.js
@@ -190,7 +190,7 @@ class SignedUrlService {
 	create({path, fileType, action, download, flatFileName}, params) {
 		path = removeLeadingSlash(pathUtil.normalize(path)); // remove leading and double slashes
 		let userId = params.payload.userId;
-		let fileName = pathUtil.basename(path);
+		let fileName = encodeURIComponent(pathUtil.basename(path));
 		let dirName = pathUtil.dirname(path);
 
 		// normalize utf-8 chars
@@ -459,6 +459,8 @@ class NewFileService {
 	create(data, params) {
 		const {path, name, key, studentCanEdit, schoolId} = data;
 
+		let newKey = `${path}${encodeURIComponent(name)}`;
+
 		let signedUrlService = this.app.service('fileStorage/signedUrl');
 		let fType = name.split('.');
 		fType = fType[fType.length - 1];
@@ -470,7 +472,7 @@ class NewFileService {
 			path: key,
 			fileType: returnFileType(name),
 			action: 'putObject',
-			flatFileName: flatFileName,
+			flatFileName: encodeURIComponent(flatFileName),
 			userId: params.account.userId
 		}).then(signedUrl => {
 			let options = {
@@ -483,9 +485,9 @@ class NewFileService {
 				return FileModel.create({
 					path,
 					name,
-					key,
+					key: newKey,
 					size: buffer.length,
-					flatFileName: flatFileName,
+					flatFileName: encodeURIComponent(flatFileName),
 					type: returnFileType(name),
 					thumbnail: 'https://schulcloud.org/images/login-right.png',
 					studentCanEdit,

--- a/src/services/wopi/index.js
+++ b/src/services/wopi/index.js
@@ -94,6 +94,7 @@ class WopiFilesContentsService {
 		// check whether a valid file is requested
 		return FileModel.findOne({_id: fileId}).then(file => {
 			if (!file) throw new errors.NotFound("The requested file was not found!");
+			file.key = decodeURIComponent(file.key);
 
 			// generate signed Url for fetching file from storage
 			return signedUrlService.create({
@@ -128,6 +129,7 @@ class WopiFilesContentsService {
 		// check whether a valid file is requested
 		return FileModel.findOne({_id: fileId}).then(file => {
 			if (!file) throw new errors.NotFound("The requested file was not found!");
+			file.key = decodeURIComponent(file.key);
 
 			// generate signedUrl for updating file to storage
 			return signedUrlService.create({


### PR DESCRIPTION
Reverted back to using the file encoding for the files as utf8 can not be used in an url, the reason why it failed is that wopi is all handled in the backend and didn't care about the encoding as the binary stream is just provided to the request.

Uploading a file with utf8 (spaces/special characters) worked before as the encoding was handled in the client.
Creating a new file from the client did not work, as the server nor the client encoded the file names and was thereby inconsistent with the rest of the file system.

To verify that it works use the following scenario:
- [ ] create new file in client with spaces and special characters
following requests on the server:
- [ ] GET /wopi/files/$FILE_ID
- [ ] GET /wopi/files/$FILE_ID/contents

add Header `X-WOPI-Override` with value `PUT` and change the Body to raw and write something random in it:
- [ ] POST /wopi/files/$FILE_ID/contents

to verify: 
- [ ] GET /wopi/files/$FILE_ID/contents

Other scenarios to test:
Upload a docx with spaces and special characters in the name and redo the steps.
Upload a picture with special characters and spaces.
