### PR TITLE
NC-92: Fix Firstlogin that was not triggered on any user anymore

### DIFF
--- a/src/services/consent/hooks/consents.js
+++ b/src/services/consent/hooks/consents.js
@@ -110,12 +110,14 @@ const accessCheck = (consent, app) => {
 	let access = true;
 	let requiresParentConsent = true;
 	let user;
+	let patchFirstlogin = false;
 
 	return app.service('users').get((consent.userId), { query: { $populate: 'roles'}})
 		.then(response => {
 			user = response;
 			if (userHasOneRole(user, ["demoTeacher", "demoStudent"])) {
 				requiresParentConsent = false;
+				patchFirstlogin = true;
 				return Promise.resolve();
 			}
 
@@ -123,10 +125,13 @@ const accessCheck = (consent, app) => {
 				let userConsent = consent.userConsent || {};
 				requiresParentConsent = false;
 				if (!(userConsent.privacyConsent && userConsent.termsOfUseConsent &&
-					userConsent.thirdPartyConsent && userConsent.researchConsent)) {
+					userConsent.thirdPartyConsent && userConsent.researchConsent)) 
+				{
 						access = false;
 						return Promise.resolve();
-					}
+				} else {
+					patchFirstlogin = true;
+				}
 				return Promise.resolve();
 			}
 
@@ -162,7 +167,7 @@ const accessCheck = (consent, app) => {
 			}
 		})
 		.then(() => {
-			if (access == true && !(user.preferences || {}).firstLogin) {
+			if (patchFirstlogin == true && !(user.preferences || {}).firstLogin) {
 				let updatedPreferences = user.preferences || {};
 				updatedPreferences.firstLogin = true;
 				return app.service('users').patch(user._id, {preferences: updatedPreferences});

--- a/src/services/consent/hooks/consents.js
+++ b/src/services/consent/hooks/consents.js
@@ -174,6 +174,11 @@ const accessCheck = (consent, app) => {
 			}
 			return;
 		}).then(() => {
+			if (access && !(user.preferences || {}).firstLogin) {
+				access = false;
+			}
+			return;
+		}).then(() => {
 			consent.access = access;
 			consent.requiresParentConsent = requiresParentConsent;
 			return consent;


### PR DESCRIPTION
https://ticketsystem.schul-cloud.org/browse/NC-92
Rebuild from old registration to new registration without redirectdic got a bug where every user got a firstlogin flag patched in which results in skipping firstlogin process even if needed.
Rebuilt status as before: 
1) Only demo users and staff will get patched with firstlogin
2) If access is valid (consents as needed) but no firstlogin is set, revoke access which results in redirect to firstlogin process of login controller