### PR TITLE
N21: Fix broken user management

### DIFF
--- a/src/services/consent/hooks/consents.js
+++ b/src/services/consent/hooks/consents.js
@@ -203,6 +203,8 @@ const decorateConsents = (hook) => {
 	const consentPromises = (hook.result.data || []).map(consent => {
 		return accessCheck(consent, hook.app).then(result => {
 			return result;
+		}).catch(err => {
+			return {};
 		});
 	});
 


### PR DESCRIPTION
2 issues existed within user (student/teacher) management:
1) crash if there are no users (school without students or teachers) - client-side, fixed in client #965 (NBC) and #918 (HSC)
2) crash if consent exists with an unknown userId (eg deleted user, consents dont get deleted), crashed within decorateConsents() - server-side, this here is NBC fix

Test: Create user, do registration (consent is created), delete user with user management UI (user is deleted, consent is not), open user management, which is displayed

@Metauriel Can this catch be problematic in any other way/logic? Please check that after your vacation.