### PR TITLE
WIP: SC-159-multifile-upload

### DIFF
--- a/src/services/fileStorage/proxy-service.js
+++ b/src/services/fileStorage/proxy-service.js
@@ -249,14 +249,21 @@ class DirectoryService {
 		let fileName = pathUtil.basename(path);
 		let dirName = pathUtil.dirname(path) + "/";
 
-		return filePermissionHelper.checkPermissions(userId, path)
-			.then(_ => {
-				// create db entry for new directory
-				return DirectoryModel.create({
-					key: path,
-					name: fileName,
-					path: dirName
-				});
+		return DirectoryModel.find({key: path}).exec()
+			.then(res => {
+				// directory already exists
+				if (res.length > 0)
+					return res[0];
+
+				return filePermissionHelper.checkPermissions(userId, path)
+					.then(_ => {
+						// create db entry for new directory
+						return DirectoryModel.create({
+							key: path,
+							name: fileName,
+							path: dirName
+						});
+					});
 			});
 	}
 


### PR DESCRIPTION
instead of throwing an error for already existing folders just return the folder.

might change it back and add a better error than 'internal sever error'