### PR TITLE
Fix npm scripts on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "startd": "nodemon src/",
     "debug": "nodemon --inspect=5959 src/",
     "coverage": "NODE_ENV=test nyc --reporter=text-summary node_modules/.bin/_mocha -- -- test/**/*.test.js",
+    "coverage-windows": "set NODE_ENV=test&&nyc --reporter=text-summary node_modules/.bin/_mocha -- -- test/**/*.test.js",
     "mocha": "NODE_ENV=test mocha test/ --recursive",
-    "mocha-windows": "set NODE_ENV=test && mocha test/ --recursive",
+    "mocha-windows": "set NODE_ENV=test&& mocha test/ --recursive",
     "mocha-inspect": "NODE_ENV=test mocha --debug-brk --inspect test/ --recursive",
-    "mocha-test-specific-windows": "set NODE_ENV=test && mocha test/app.hooks.test.js"
+    "mocha-test-specific-windows": "set NODE_ENV=test&& mocha test/app.hooks.test.js"
   },
   "dependencies": {
     "aws-sdk": "^2.306.0",


### PR DESCRIPTION
Maybe we should use something like https://www.npmjs.com/package/cross-env to consolidate our build scripts (to remove all the "...-windows" scripts). I'd be happy to provide this in a separate PR.