### PR TITLE
Update build scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -237,7 +237,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -863,6 +863,31 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
+      }
+    },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -1534,7 +1559,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -1553,7 +1578,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -2820,6 +2845,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -6529,7 +6560,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -6763,7 +6794,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "lint": "eslint ./src ./test --ext .js --fix",
-    "seed": "sh ./backup.sh -p setup/ -D schulcloud-test -a import",
+    "seed": "./backup.sh -p setup/ -D schulcloud-test -a import",
     "test": "cross-env NODE_ENV=test npm run seed && npm run coverage",
     "backup": "./backup.sh -a -b export",
     "setup": "./backup.sh -p setup/ -a import",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "winston": "^2.3.0"
   },
   "devDependencies": {
+    "cross-env": "^5.2.0",
     "eslint": "^5.10.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -17,19 +17,16 @@
   },
   "scripts": {
     "lint": "eslint ./src ./test --ext .js --fix",
-    "test": "./backup.sh -p setup/ -D schulcloud-test -a import && npm run coverage",
-    "test-windows": "sh ./backup.sh -p setup/ -D schulcloud-test -a import && npm run lint && npm run mocha-windows",
-    "test-windows-wo-db": "npm run lint && npm run mocha-windows",
+    "seed": "sh ./backup.sh -p setup/ -D schulcloud-test -a import",
+    "test": "cross-env NODE_ENV=test npm run seed && npm run coverage",
     "backup": "./backup.sh -a -b export",
     "setup": "./backup.sh -p setup/ -a import",
     "start": "node src/",
     "startd": "nodemon src/",
     "debug": "nodemon --inspect=5959 src/",
-    "coverage": "NODE_ENV=test nyc --reporter=text-summary node_modules/.bin/_mocha -- -- test/**/*.test.js",
-    "mocha": "NODE_ENV=test mocha test/ --recursive",
-    "mocha-windows": "set NODE_ENV=test && mocha test/ --recursive",
-    "mocha-inspect": "NODE_ENV=test mocha --debug-brk --inspect test/ --recursive",
-    "mocha-test-specific-windows": "set NODE_ENV=test && mocha test/app.hooks.test.js"
+    "coverage": "cross-env NODE_ENV=test nyc --reporter=text-summary node_modules/.bin/_mocha -- -- test/**/*.test.js",
+    "mocha": "cross-env NODE_ENV=test mocha test/ --recursive",
+    "mocha-inspect": "cross-env NODE_ENV=test mocha --debug-brk --inspect test/ --recursive"
   },
   "dependencies": {
     "aws-sdk": "^2.306.0",


### PR DESCRIPTION
CC: @schul-cloud/coredevs @schul-cloud/hiwis @schul-cloud/masterstudis 

I've added cross-env to de-clutter our build-scripts (no more *-windows scripts!). In the process I removed scripts that I thought are unnecessary. If you need them, please report here.

One thing is still annoying on Windows: We're still depending on Git Bash (due to backup.sh). You can use `npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"` (update for your system!) to use git bash for all npm build scripts. This is most likely required on Windows with this PR. However, implicitly, it was already a requirement. In the future, we could migrate to platform-independent (node-based) scripts.