### PR TITLE
Fix 2 problems at once: no more timestamp prefix

### DIFF
--- a/src/services/fileStorage/proxy-service.js
+++ b/src/services/fileStorage/proxy-service.js
@@ -323,7 +323,7 @@ const signedUrlService = {
 
 		return canRead(userId, file)
 			.then(() => strategy.getSignedUrl(
-				{ userId: creatorId, flatFileName: fileObject.storageFileName, download },
+				{ userId: creatorId, flatFileName: fileObject.storageFileName, localFileName: fileObject.name, download },
 			))
 			.then(res => ({
 				url: res,

--- a/src/services/fileStorage/strategies/awsS3.js
+++ b/src/services/fileStorage/strategies/awsS3.js
@@ -266,7 +266,7 @@ class AWSS3Strategy extends AbstractFileStorageStrategy {
 			});
 	}
 
-	getSignedUrl({userId, flatFileName, download, action = 'getObject' }) {
+	getSignedUrl({userId, flatFileName, localFileName, download, action = 'getObject' }) {
 		if ( !userId || !flatFileName ) return Promise.reject(new errors.BadRequest('Missing parameters'));
 
 		return UserModel.userModel.findById(userId).exec().then(result => {
@@ -279,8 +279,8 @@ class AWSS3Strategy extends AbstractFileStorageStrategy {
 				Expires: 60
 			};
 
-			if( download ) {
-				params["ResponseContentDisposition"] = `attachment; filename = ${flatFileName}`;
+			if(download) {
+				params["ResponseContentDisposition"] = `attachment; filename = ${localFileName}`;
 			}
 
 			return promisify(awsObject.s3.getSignedUrl, awsObject.s3)(action, params);


### PR DESCRIPTION
and renamed files now initiate this filename at
download instead S3 real filename
https://ticketsystem.schul-cloud.org/browse/SC-963
