### PR TITLE
Naming and allow additional feature flags in team create.

### DIFF
--- a/src/services/rocketChat/index.js
+++ b/src/services/rocketChat/index.js
@@ -477,11 +477,11 @@ class RocketChatChannel {
 		return this.getOrCreateRocketChatChannel(teamId, params);
 	}
 
-	static _onTeamPatched(context) {
-		if (context.features.includes('rocketChat')) {
-			RocketChatChannel.unarchiveChannel(context._id);
+	static _onTeamPatched(result) {
+		if (result.features.includes('rocketChat')) {
+			RocketChatChannel.unarchiveChannel(result._id);
 		} else {
-			RocketChatChannel.archiveChannel(context._id);
+			RocketChatChannel.archiveChannel(result._id);
 		}
 	}
 

--- a/src/services/teams/hooks/helpers.js
+++ b/src/services/teams/hooks/helpers.js
@@ -142,7 +142,12 @@ exports.updateMissingDataInHookForCreate = (hook, sessionUser) => {
 	}
 
 	// add team flag
-	hook.data.features = ['isTeam'];
+	if (hook.data.features) {
+		hook.data.features.push('isTeam');
+	} else {
+		hook.data.features = ['isTeam'];
+	}
+
 	addDefaultFilePermissions(hook);
 
 	hook.data.schoolIds = [schoolId];


### PR DESCRIPTION
Beim erstellen eines neuen Teams wird das flag für RocketChat jetzt richtig mit übernommen und nicht beim team create überschrieben. 