### PR TITLE
change identifier for travis and stickler

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,10 +4,10 @@ pullapprove_conditions:
 - condition: "'WIP' not in labels"
   unmet_status: pending
   explanation: "Work in progress"
-- condition: "'*Travis*' in statuses.succeeded"
+- condition: "'Travis*' in statuses.succeeded"
   unmet_status: failure
   explanation: "Tests must pass before review starts"
-- condition: "'*stickler*' in statuses.succeeded"
+- condition: "'stickler*' in statuses.succeeded"
   unmet_status: failure
   explanation: "Linter must pass before review starts"
 
@@ -28,7 +28,7 @@ groups:
       - server-core
     reviews:
       required: 1  # number of approvals required from this group
-      request: 1  # number of review requests sent at a time
+      request: 2  # number of review requests sent at a time
       request_order: shuffle
 
   privacy:
@@ -41,5 +41,5 @@ groups:
       - data-protection
     reviews:
       required: 1  # number of approvals required from this group
-      request: 1  # number of review requests sent at a time
+      request: 2  # number of review requests sent at a time
       request_order: shuffle

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,3 @@
-<!-- presettings
-labels: ["WIP"]
---->
 # Checkliste
 
 - Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein


### PR DESCRIPTION
change number of requested reviewers

<!-- presettings
labels: ["WIP"]
--->
# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-client/pulls/????
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-????

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig / Migrationsskripte
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt
- [x] mind. 1 Screenshot bei Content-Änderungen

## Datenschutz
- [x] Model- / Seedänderungen erfordern Review der Datenschutz-Gruppen (wird automatisch hinzugefügt)
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
