### PR TITLE
SC-759 delete team news after deleting the team

### DIFF
--- a/src/services/index.js
+++ b/src/services/index.js
@@ -33,12 +33,20 @@ const rocketChat = require('./rocketChat');
 const clipboard = require('./clipboard');
 const me = require('./me');
 
-module.exports = function () {
+const newsEvents = require('./news/events');
+
+module.exports = function initializeServices() {
 	const app = this;
 
-	mongoose.connect(process.env.DB_URL || app.get('mongodb'), { user: process.env.DB_USERNAME, pass: process.env.DB_PASSWORD });
+	// connect mongoose to the database
+	const dbCredentials = {
+		user: process.env.DB_USERNAME,
+		pass: process.env.DB_PASSWORD,
+	};
+	mongoose.connect(process.env.DB_URL || app.get('mongodb'), dbCredentials);
 	mongoose.Promise = global.Promise;
 
+	// register services
 	app.configure(authentication);
 	app.configure(analytics);
 	app.configure(user);
@@ -72,4 +80,7 @@ module.exports = function () {
 	app.configure(sync);
 	app.configure(me);
 	app.configure(rocketChat);
+
+	// initialize events
+	newsEvents.configure(app);
 };

--- a/src/services/news/events/index.js
+++ b/src/services/news/events/index.js
@@ -1,0 +1,23 @@
+const logger = require('winston');
+
+const removeTeamNews = (app, newsService) => async (deletedTeam) => {
+	try {
+		await newsService.remove(null, {
+			query: {
+				target: deletedTeam._id,
+				targetModel: 'teams',
+			},
+		});
+	} catch (e) {
+		logger.warn(`Cannot remove news for team ${deletedTeam._id}`, e);
+	}
+};
+
+const configure = (app) => {
+	const newsService = app.service('news');
+	app.service('teams').on('removed', removeTeamNews(app, newsService));
+};
+
+module.exports = {
+	configure,
+};

--- a/src/services/news/hooks/index.js
+++ b/src/services/news/hooks/index.js
@@ -42,7 +42,13 @@ exports.before = {
 	create: [globalHooks.hasPermission('NEWS_CREATE')],
 	update: [globalHooks.hasPermission('NEWS_EDIT'), restrictToCurrentSchool],
 	patch: [globalHooks.hasPermission('NEWS_EDIT'), restrictToCurrentSchool, globalHooks.permitGroupOperation],
-	remove: [globalHooks.hasPermission('NEWS_CREATE'), restrictToCurrentSchool, globalHooks.permitGroupOperation, deleteNewsHistory, globalHooks.ifNotLocal(globalHooks.checkSchoolOwnership)]
+	remove: [
+		globalHooks.hasPermission('NEWS_CREATE'),
+		globalHooks.ifNotLocal(globalHooks.permitGroupOperation),
+		restrictToCurrentSchool,
+		deleteNewsHistory,
+		globalHooks.ifNotLocal(globalHooks.checkSchoolOwnership),
+	],
 };
 
 exports.after = {

--- a/src/services/news/index.js
+++ b/src/services/news/index.js
@@ -1,6 +1,7 @@
 const service = require('feathers-mongoose');
 const { newsModel, newsHistoryModel } = require('./model');
 const hooks = require('./hooks');
+const events = require('./events');
 
 module.exports = function news() {
 	const app = this;
@@ -22,4 +23,6 @@ module.exports = function news() {
 	const NewsHistoryService = app.service('/newshistory');
 	NewsHistoryService.before(hooks.before);
 	NewsHistoryService.after(hooks.after);
+
+	events.configure(app);
 };

--- a/src/services/news/index.js
+++ b/src/services/news/index.js
@@ -1,7 +1,6 @@
 const service = require('feathers-mongoose');
 const { newsModel, newsHistoryModel } = require('./model');
 const hooks = require('./hooks');
-const events = require('./events');
 
 module.exports = function news() {
 	const app = this;
@@ -23,6 +22,4 @@ module.exports = function news() {
 	const NewsHistoryService = app.service('/newshistory');
 	NewsHistoryService.before(hooks.before);
 	NewsHistoryService.after(hooks.after);
-
-	events.configure(app);
 };

--- a/test/services/news/index.test.js
+++ b/test/services/news/index.test.js
@@ -21,12 +21,12 @@ describe('news service', () => {
 					target: teamId,
 					targetModel: 'teams',
 				}).save();
+				expect(await News.count({ _id: teamNews._id })).to.equal(1);
 
 				app.service('teams').emit('removed', { _id: teamId });
 				await sleep(100); // give the event listener time to work
 
-				const result = await News.count({ _id: teamNews._id });
-				expect(result).to.equal(0);
+				expect(await News.count({ _id: teamNews._id })).to.equal(0);
 			});
 
 			it('does not delete any other news', async () => {

--- a/test/services/news/index.test.js
+++ b/test/services/news/index.test.js
@@ -3,27 +3,69 @@ const { ObjectId } = require('mongoose').Types;
 const sleep = require('util').promisify(setTimeout);
 
 const app = require('../../../src/app');
-const NewsModel = require('../../../src/services/news/model').newsModel;
+const News = require('../../../src/services/news/model').newsModel;
 
 describe('news service', () => {
 	it('registers correctly', () => {
 		expect(app.service('news')).to.not.equal(undefined);
 	});
 
-	it('deletes team news after a team is deleted', async () => {
-		const teamId = new ObjectId();
-		const teamNews = await new NewsModel({
-			schoolId: new ObjectId(),
-			title: 'team news',
-			content: 'here are some news concerning this team',
-			target: teamId,
-			targetModel: 'teams',
+	describe('event handlers', () => {
+		describe('team news', () => {
+			it('is deleted after the coresponding team is deleted', async () => {
+				const teamId = new ObjectId();
+				const teamNews = await new News({
+					schoolId: new ObjectId(),
+					title: 'team news',
+					content: 'here are some news concerning this team',
+					target: teamId,
+					targetModel: 'teams',
+				}).save();
+
+				app.service('teams').emit('removed', { _id: teamId });
+				await sleep(100); // give the event listener time to work
+
+				const result = await News.count({ _id: teamNews._id });
+				expect(result).to.equal(0);
+			});
+
+			it('does not delete any other news', async () => {
+				const schoolId = new ObjectId();
+				const teamId = new ObjectId();
+				await new News({
+					schoolId,
+					title: 'team news',
+					content: 'here are some news concerning this team',
+					target: teamId,
+					targetModel: 'teams',
+				}).save();
+				const courseId = new ObjectId();
+				const courseNews = await new News({
+					schoolId,
+					title: 'course news',
+					content: 'here are some news concerning this course',
+					target: courseId,
+					targetModel: 'courses',
+				}).save();
+				const schoolNews = await new News({
+					schoolId,
+					title: 'global school news',
+					content: 'yo ho ho, and a bottle of rum',
+				}).save();
+
+				const newsCount = await News.count({ schoolId });
+				expect(newsCount).to.equal(3);
+
+				app.service('teams').emit('removed', { _id: teamId });
+				await sleep(100); // give the event listener time to work
+
+				const result = await News.count({ schoolId });
+				expect(result).to.equal(2);
+
+				await News.remove({
+					_id: { $in: [courseNews._id, schoolNews._id] },
+				});
+			});
 		});
-
-		app.service('teams').emit('deleted', { _id: teamId });
-		await sleep(20); // give the event listener time to work
-
-		const result = await NewsModel.count({ _id: teamNews._id });
-		expect(result).to.equal(0);
 	});
 });

--- a/test/services/news/index.test.js
+++ b/test/services/news/index.test.js
@@ -1,10 +1,29 @@
-'use strict';
+const { expect } = require('chai');
+const { ObjectId } = require('mongoose').Types;
+const sleep = require('util').promisify(setTimeout);
 
-const assert = require('assert');
 const app = require('../../../src/app');
+const NewsModel = require('../../../src/services/news/model').newsModel;
 
-describe('news service', function() {
-  it('registered the news service', () => {
-    assert.ok(app.service('news'));
-  });
+describe('news service', () => {
+	it('registers correctly', () => {
+		expect(app.service('news')).to.not.equal(undefined);
+	});
+
+	it('deletes team news after a team is deleted', async () => {
+		const teamId = new ObjectId();
+		const teamNews = await new NewsModel({
+			schoolId: new ObjectId(),
+			title: 'team news',
+			content: 'here are some news concerning this team',
+			target: teamId,
+			targetModel: 'teams',
+		});
+
+		app.service('teams').emit('deleted', { _id: teamId });
+		await sleep(20); // give the event listener time to work
+
+		const result = await NewsModel.count({ _id: teamNews._id });
+		expect(result).to.equal(0);
+	});
 });


### PR DESCRIPTION
Event-Listener im News-Service, der auf `team:removed` hört und dann betreffende News löscht.

## Allgemein
- [X] ~~Links zu verwandten PRs anderer Repositories~~
  - ~~https://github.com/schul-cloud/schulcloud-client/pulls/????~~
  - ~~Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen~~
- [X] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-759

## Code Qualität
- [X] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [X] Kern-Logik ist hinter der API implementiert?

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [X] Unit-Tests und Integrations-Tests schreiben / ändern
- [X] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [X] ~~Feature Toggle notwendig (z.B. Environment-Variablen)~~
- [X] ~~Datenbankanpassungen notwendig / Migrationsskripte~~
  - ~~Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden~~
- [X] ~~Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen~~

## Dokumentation
- [X] ~~Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)~~
- [X] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [X] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt
- [X] ~~mind. 1 Screenshot bei Content-Änderungen~~

## Datenschutz
- [X] ~~Model- / Seedänderungen erfordern Review der Datenschutz-Gruppen (wird automatisch hinzugefügt)~~
- [X] ~~Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen~~

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
