### PR TITLE
fix-permission-check-for-private-tasks

### DIFF
--- a/src/services/homework/hooks/index.js
+++ b/src/services/homework/hooks/index.js
@@ -72,7 +72,7 @@ const hasViewPermissionAfter = (hook) => {
 	// user is teacher OR ( user is in courseId of task AND availableDate < Date.now() )
 	// availableDate < Date.now()
 	function hasPermission(e) {
-		const isTeacherCheck = (e.teacherId === (hook.params.account || {}).userId)
+		const isTeacherCheck = (e.teacherId === (hook.params.account || {}).userId.toString())
             || (!e.private && ((e.courseId || {}).teacherIds || []).includes((hook.params.account || {}).userId.toString()))
             || (!e.private && ((e.courseId || {}).substitutionIds || []).includes((hook.params.account || {}).userId.toString()));
 		const isStudent = ((e.courseId != null)


### PR DESCRIPTION
Zu diesem Bug gibt es bisher kein Ticket. In homework/hooks/index.js wurde beim Fixen der Linter-Errors == durch === ersetzt. Durch die fehlende Umwandlung der userId in einen String in hasViewPermissionAfter() wurden private Aufgaben daraufhin auch ihren Erstellern nicht mehr angezeigt.

# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-client/pulls/????
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-????

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt

## Datenschutz
- [x] Model- / Seedänderungen erfordern Review der Datenschutz-Gruppen (wird automatisch hinzugefügt)
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
