### PR TITLE
Hotfix/SC-1306 Fix too long firstlogin

### DIFF
--- a/src/services/user/index.js
+++ b/src/services/user/index.js
@@ -29,7 +29,7 @@ class UserLinkImportService {
 	get(hash, params) {	//can not use get becouse the hash can have / that mapped to non existing routes
 		return this.userService.find({ query: { importHash: hash } })
 			.then(users => {
-				if (users.data.length <= 0 || users.data.length > 1) {
+				if (users.data.length !== 1) {
 					throw new errors.BadRequest('Can not match the hash.');
 				}
 				return userDataFilter(users.data[0]);

--- a/src/services/user/registration.js
+++ b/src/services/user/registration.js
@@ -199,8 +199,8 @@ const registerUser = function(data, params, app) {
 		//store consent
 		consent = {
 			form: 'digital',
-			privacyConsent: data.privacyConsent,
-			termsOfUseConsent: data.termsOfUseConsent,
+			privacyConsent: (data.privacyConsent || data.parent_privacyConsent) === 'true',
+			termsOfUseConsent: (data.termsOfUseConsent || data.parent_termsOfUseConsent) === 'true',
 		};
 		if (parent) {
 			consent.parentId = parent._id;

--- a/src/services/user/registration.js
+++ b/src/services/user/registration.js
@@ -197,15 +197,20 @@ const registerUser = function(data, params, app) {
 		}
 	}).then(function(){
 		//store consent
-		consent = {
-			form: 'digital',
-			privacyConsent: (data.privacyConsent || data.parent_privacyConsent) === 'true',
-			termsOfUseConsent: (data.termsOfUseConsent || data.parent_termsOfUseConsent) === 'true',
-		};
 		if (parent) {
-			consent.parentId = parent._id;
+			consent = {
+				form: 'digital',
+				parentId: parent._id,
+				privacyConsent: data.parent_privacyConsent === 'true',
+				termsOfUseConsent: data.parent_termsOfUseConsent === 'true',
+			};
 			consentPromise = app.service('consents').create({userId: user._id,parentConsents: [consent]});
 		} else {
+			consent = {
+				form: 'digital',
+				privacyConsent: data.privacyConsent === 'true',
+				termsOfUseConsent: data.termsOfUseConsent === 'true',
+			};
 			consentPromise = app.service('consents').create({userId: user._id, userConsent: consent});
 		}
 		return consentPromise


### PR DESCRIPTION
# Checkliste
Client-PR: https://github.com/schul-cloud/schulcloud-client/pull/1195
Formularfelder wurden beim Ausfüllen durch Eltern (Registration unter 16) nicht korrekt erkannt und der Consent mit falses abgespeichert. Dadurch wurde im Firstlogin nochmal nach Elternconsents gefragt.

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-client/pull/1195
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-1306

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde