### PR TITLE
[SC-1538] Check read permissions of parent directory before searching for files

### DIFF
--- a/src/services/fileStorage/proxy-service.js
+++ b/src/services/fileStorage/proxy-service.js
@@ -150,8 +150,10 @@ const fileStorageService = {
 	find({ query, payload }) {
 		const { owner, parent } = query;
 		const { userId } = payload;
+		const parentPromise = parent ? canRead(userId, parent) : Promise.resolve();
 
-		return FileModel.find({ owner, parent: parent || { $exists: false } }).exec()
+		return parentPromise
+			.then(() => FileModel.find({ owner, parent: parent || { $exists: false } }).exec())
 			.then((files) => {
 				const permissionPromises = files.map(
 					f => canRead(userId, f)
@@ -167,6 +169,10 @@ const fileStorageService = {
 				}
 
 				return files;
+			})
+			.catch((e) => {
+				logger.error(e);
+				return Promise.reject(new Forbidden());
 			});
 	},
 


### PR DESCRIPTION
Es wird nun auch die Ordner-Berechtigung geprüft, wenn man versucht Dateien darunter zu finden.

## Allgemein
- [X] ~~Links zu verwandten PRs anderer Repositories~~
- [X] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-1538

## Code Qualität
- [X] Code mit Hinblick auf Security und Datensicherheit betrachten
- [X] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [X] Kern-Logik ist hinter der API implementiert?

## Tests
- [X] Test-Coverage darf durch PR nicht sinken
- [X] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- keine Änderungen erforderlich

## Dokumentation
- [X] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [X] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [X] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt

## Datenschutz
- nicht nötig

## Freigabe zum Review
- [X] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde
