### PR TITLE
Improve CSV-Importer handling of duplicate classes

### DIFF
--- a/src/services/sync/strategies/CSVSyncer.js
+++ b/src/services/sync/strategies/CSVSyncer.js
@@ -418,7 +418,8 @@ class CSVSyncer extends Syncer {
 
 	async buildClassMapping(classes) {
 		const classMapping = {};
-		await Promise.all(classes.map(async (klass) => {
+		const uniqueClasses = [...new Set(classes)];
+		await Promise.all(uniqueClasses.map(async (klass) => {
 			try {
 				if (classMapping[klass] === undefined) {
 					const classObject = await this.getClassObject(klass);

--- a/test/services/sync/strategies/CSVSyncer/CSVSyncer.integration.test.js
+++ b/test/services/sync/strategies/CSVSyncer/CSVSyncer.integration.test.js
@@ -204,7 +204,7 @@ describe('CSVSyncer Integration', () => {
 			scenarioData = {
 				data: 'firstName,lastName,email,class\n'
 					+ `Turanga,Leela,${STUDENT_EMAILS[0]},\n`
-					+ `Dr. John A.,Zoidberg,${STUDENT_EMAILS[1]},1a\n`
+					+ `Dr. John A.,Zoidberg,${STUDENT_EMAILS[1]},1a+1a\n`
 					+ `Amy,Wong,${STUDENT_EMAILS[2]},1a\n`
 					+ `Philip J.,Fry,${STUDENT_EMAILS[3]},1b+2b\n`
 					+ `Bender Bending,Rodriguez,${STUDENT_EMAILS[4]},2b+2c\n`,

--- a/test/services/sync/strategies/CSVSyncer/CSVSyncer.integration.test.js
+++ b/test/services/sync/strategies/CSVSyncer/CSVSyncer.integration.test.js
@@ -257,6 +257,8 @@ describe('CSVSyncer Integration', () => {
 			expect(classes[2].length).to.equal(1);
 			expect(classes[2][0].gradeLevel).to.equal(1);
 			expect(classes[2][0].name).to.equal('a');
+			expect(classes[1][0]._id).not.to.equal(undefined);
+			expect(classes[1][0]._id.toString()).to.equal(classes[2][0]._id.toString());
 			expect(classes[3].length).to.equal(2);
 			expect(classes[4].length).to.equal(2);
 

--- a/test/services/sync/strategies/CSVSyncer/CSVSyncer.unit.test.js
+++ b/test/services/sync/strategies/CSVSyncer/CSVSyncer.unit.test.js
@@ -101,13 +101,12 @@ describe('CSVSyncer', () => {
 			}
 		});
 
-		it('should trim leading zeros for grade levels', () => {
-			['02a', '05b', '09c', '012d', '007e', '0000010f'].forEach(async (input) => {
+		it('should trim leading zeros for grade levels', async () => {
+			await Promise.all(['02a', '05b', '09c', '012d', '007e', '0000010f'].map(async (input) => {
 				const result = await new CSVSyncer(app).getClassObject(input);
-				expect(result.nameFormat).to.equal('gradeLevel+name');
-				expect(result.gradeLevel.name).to.equal(input.match(/^0*(\d+)./)[1]);
+				expect(result.gradeLevel).to.equal(input.match(/^0*(\d+)./)[1]);
 				expect(result.name).to.equal(input.replace(/\d*/, ''));
-			});
+			}));
 		});
 	});
 });


### PR DESCRIPTION
- [X] without ticket 😄 

Quick-win fix for CSV files with users that are put in one class multiple times (e.g. `1a+1a+1a`) and hardening of tests.