### PR TITLE
Hotfix/19.3.2 update s3 cors rules

### DIFF
--- a/config/secrets.js
+++ b/config/secrets.js
@@ -15,7 +15,7 @@ let secrets = {
 		"cors_rules": [{
 		"AllowedHeaders": ["*"],
 		"AllowedMethods": ["PUT"],
-		"AllowedOrigins": ["https://schul-cloud.org", "https://schulcloud.org", "https://schul.tech"],
+		"AllowedOrigins": [process.env.HOST],
 		"MaxAgeSeconds": 300
 	}]
 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "schulcloud-server",
-  "version": "19.3.1",
+  "version": "19.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2338,7 +2338,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -2363,7 +2363,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -5459,7 +5459,7 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "schulcloud-server",
   "description": "hpi schulcloud server",
-  "version": "19.3.1",
+  "version": "19.3.2",
   "homepage": "https://schul-cloud.org",
   "main": "src/",
   "keywords": [


### PR DESCRIPTION
Kein Ticket:
Statt statischer Allowed Origins und anstelle *alle* Instanzen in allen Instanzen zuzulassen (Risiko) wird jetzt immer nur die aktuelle Instanz als erlaubte Quelle des Buckets eingetragen.