### PR TITLE
LDAP fix no specific user folder

### DIFF
--- a/src/services/account/hooks/index.js
+++ b/src/services/account/hooks/index.js
@@ -99,7 +99,7 @@ const validatePassword = (hook) => {
 				(hasStudentCreate && isStudent)
 				|| (hasAdminView && (isStudent || isTeacher))
 				|| isSuperHero
-				|| editsOwnAccount) {
+				|| !editsOwnAccount) {
 				return hook;
 			}
 			if (password && !passwordVerification) {

--- a/src/services/account/hooks/index.js
+++ b/src/services/account/hooks/index.js
@@ -99,7 +99,7 @@ const validatePassword = (hook) => {
 				(hasStudentCreate && isStudent)
 				|| (hasAdminView && (isStudent || isTeacher))
 				|| isSuperHero
-				|| !editsOwnAccount) {
+				|| editsOwnAccount) {
 				return hook;
 			}
 			if (password && !passwordVerification) {

--- a/src/services/ldap/strategies/general.js
+++ b/src/services/ldap/strategies/general.js
@@ -55,7 +55,10 @@ class GeneralLDAPStrategy extends AbstractLDAPStrategy {
 
 		const rawAttributes = [userAttributeNameMapping.uuid];
 
-		const searchString = `${userPathAdditions},${this.config.rootPath}`;
+		const searchString = (userPathAdditions === '')
+			? this.config.rootPath
+			: `${userPathAdditions},${this.config.rootPath}`;
+
 		return this.app.service('ldap').searchCollection(this.config, searchString, options, rawAttributes)
 			.then((data) => {
 				const results = [];


### PR DESCRIPTION
# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-client/pull/????
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-????

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt

## Datenschutz
- [x] Model- / Seedänderungen erfordern Review der Datenschutz-Gruppen (wird automatisch hinzugefügt)
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
