### PR TITLE
[SC-2317] Implement security check callback service

### DIFF
--- a/src/services/fileStorage/SecurityCheckService.js
+++ b/src/services/fileStorage/SecurityCheckService.js
@@ -1,0 +1,36 @@
+const { FileModel, SecurityCheckStatusTypes } = require('./model');
+const hooks = require('./hooks/SecurityCheckService.hooks.js');
+const logger = require('../../logger');
+
+class SecurityCheckService {
+	async update(id, data) {
+		if (data.error) {
+			logger.error(`Anti-virus service cannot check file with id ${id}. Error message: '${data.error}'`, data);
+			return Promise.resolve();
+		}
+		const status = data.virus_detected === true
+			? SecurityCheckStatusTypes.blocked
+			: SecurityCheckStatusTypes.verified;
+		await FileModel.updateOne(
+			{ 'securityCheck.requestToken': id },
+			{
+				$set: {
+					'securityCheck.requestToken': null,
+					'securityCheck.status':	status,
+					'securityCheck.updatedAt': Date.now(),
+				},
+			},
+		).exec();
+		return Promise.resolve();
+	}
+
+	setup(app) {
+		this.app = app;
+	}
+}
+
+module.exports = (app) => {
+	app.use('/fileStorage/securityCheck', new SecurityCheckService());
+	const securityCheckService = app.service('/fileStorage/securityCheck');
+	securityCheckService.hooks(hooks);
+};

--- a/src/services/fileStorage/SecurityCheckService.js
+++ b/src/services/fileStorage/SecurityCheckService.js
@@ -9,8 +9,8 @@ class SecurityCheckService {
 			return Promise.resolve();
 		}
 		const status = data.virus_detected === true
-			? SecurityCheckStatusTypes.blocked
-			: SecurityCheckStatusTypes.verified;
+			? SecurityCheckStatusTypes.BLOCKED
+			: SecurityCheckStatusTypes.VERIFIED;
 		await FileModel.updateOne(
 			{ 'securityCheck.requestToken': id },
 			{

--- a/src/services/fileStorage/hooks/SecurityCheckService.hooks.js
+++ b/src/services/fileStorage/hooks/SecurityCheckService.hooks.js
@@ -1,0 +1,32 @@
+const { BadRequest } = require('@feathersjs/errors');
+const { disallow } = require('feathers-hooks-common');
+
+const parseData = (context) => {
+	if (context.data) {
+		if (context.data instanceof String || context.data instanceof Buffer) {
+			context.data = JSON.parse(context.data);
+			return context;
+		}
+	}
+	throw new BadRequest('Expected request data to exist and to be a String or a Buffer.');
+};
+
+exports.before = {
+	all: [],
+	find: [disallow('external')],
+	get: [disallow('external')],
+	create: [disallow('external')],
+	update: [parseData],
+	patch: [disallow('external')],
+	remove: [disallow('external')],
+};
+
+exports.after = {
+	all: [],
+	find: [],
+	get: [],
+	create: [],
+	update: [],
+	patch: [],
+	remove: [],
+};

--- a/src/services/fileStorage/index.js
+++ b/src/services/fileStorage/index.js
@@ -1,13 +1,12 @@
 const modelService = require('./model-service');
 const proxyService = require('./proxy-service');
 const thumbnailService = require('./thumbnail-service');
+const SecurityCheckService = require('./SecurityCheckService');
 
-module.exports = function () {
-	const app = this;
-	// Setup proxy services
+module.exports = (app) => {
 	app.configure(proxyService);
-	// Setup model services
 	app.configure(modelService);
-	// Setup thumbnail service
+
 	app.configure(thumbnailService);
+	app.configure(SecurityCheckService);
 };


### PR DESCRIPTION
**Base is main feature branch, not develop**

- [X] Link zum Ticket:
  - https://ticketsystem.schul-cloud.org/browse/SC-2317
  - https://ticketsystem.schul-cloud.org/browse/SC-1155
- [X] Verwandte PRs:
  - https://github.com/schul-cloud/schulcloud-server/pull/836

Adds a file security check callback service.

- workflow: On file upload, the proxy-service sends a request to the external service (https://github.com/schul-cloud/antivirus_check_service), parking a temporary signed URL and a response URL in a virus scan queue (see #836). Once the external service scans the file, it calls the response URL, which updates the file's status
