### PR TITLE
Tf/sc 2412 payload backwards compability

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -375,6 +375,26 @@ exports.restrictToUsersOwnCourses = (context) => getUser(context).then((user) =>
 	return context;
 });
 
+exports.mapPayload = (context) => {
+	logger.log('warning',
+		'DEPRICATED: this hook should be used to ensure backwards compability only, and be removed if possible.');
+	if (context.params.payload) {
+		context.params.authentication = Object.assign(context.params.authentication || {}, { payload: context.params.payload });
+	}
+	Object.defineProperty(context.params, 'payload', {
+		get() {
+			logger.log('warning', 'params.payload is DEPRICATED, please use params.authentication.payload instead!');
+			return (context.params.authentication || {}).payload;
+		},
+		set(v) {
+			logger.log('warning', 'params.payload is DEPRICATED, please use params.authentication.payload instead!');
+			if (!context.params.authentication) context.params.authentication = {};
+			context.params.authentication.payload = v;
+		},
+	});
+	return context;
+};
+
 exports.restrictToUsersOwnLessons = (context) => getUser(context).then((user) => {
 	if (testIfRoleNameExist(user, ['superhero', 'administrator'])) {
 		return context;

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -379,7 +379,7 @@ exports.mapPayload = (context) => {
 	logger.log('warning',
 		'DEPRECATED: this hook should be used to ensure backwards compatibility only, and be removed if possible.');
 	if (context.params.payload) {
-		context.params.authentication = Object.assign(context.params.authentication || {}, { payload: context.params.payload });
+		context.params.authentication = Object.assign({}, context.params.authentication, { payload: context.params.payload });
 	}
 	Object.defineProperty(context.params, 'payload', {
 		get() {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -377,17 +377,28 @@ exports.restrictToUsersOwnCourses = (context) => getUser(context).then((user) =>
 
 exports.mapPayload = (context) => {
 	logger.log('warning',
-		'DEPRECATED: this hook should be used to ensure backwards compatibility only, and be removed if possible.');
+		'DEPRECATED: mapPayload hook should be used to ensure backwards compatibility only, and be removed if possible.'
+		+ ` path: ${context.path} method: ${context.method}`);
 	if (context.params.payload) {
-		context.params.authentication = Object.assign({}, context.params.authentication, { payload: context.params.payload });
+		context.params.authentication = Object.assign(
+			{},
+			context.params.authentication,
+			{ payload: context.params.payload },
+		);
 	}
 	Object.defineProperty(context.params, 'payload', {
 		get() {
-			logger.log('warning', 'params.payload is DEPRECATED, please use params.authentication.payload instead!');
+			logger.log(
+				'warning', 'reading params.payload is DEPRECATED, please use params.authentication.payload instead!'
+				+ ` path: ${context.path} method: ${context.method}`,
+			);
 			return (context.params.authentication || {}).payload;
 		},
 		set(v) {
-			logger.log('warning', 'params.payload is DEPRECATED, please use params.authentication.payload instead!');
+			logger.log(
+				'warning', 'writing params.payload is DEPRECATED, please use params.authentication.payload instead!'
+				+ `path: ${context.path} method: ${context.method}`,
+			);
 			if (!context.params.authentication) context.params.authentication = {};
 			context.params.authentication.payload = v;
 		},

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -383,7 +383,7 @@ exports.mapPayload = (context) => {
 	}
 	Object.defineProperty(context.params, 'payload', {
 		get() {
-			logger.log('warning', 'params.payload is DEPRICATED, please use params.authentication.payload instead!');
+			logger.log('warning', 'params.payload is DEPRECATED, please use params.authentication.payload instead!');
 			return (context.params.authentication || {}).payload;
 		},
 		set(v) {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -387,7 +387,7 @@ exports.mapPayload = (context) => {
 			return (context.params.authentication || {}).payload;
 		},
 		set(v) {
-			logger.log('warning', 'params.payload is DEPRICATED, please use params.authentication.payload instead!');
+			logger.log('warning', 'params.payload is DEPRECATED, please use params.authentication.payload instead!');
 			if (!context.params.authentication) context.params.authentication = {};
 			context.params.authentication.payload = v;
 		},

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -377,7 +377,7 @@ exports.restrictToUsersOwnCourses = (context) => getUser(context).then((user) =>
 
 exports.mapPayload = (context) => {
 	logger.log('warning',
-		'DEPRICATED: this hook should be used to ensure backwards compability only, and be removed if possible.');
+		'DEPRECATED: this hook should be used to ensure backwards compatibility only, and be removed if possible.');
 	if (context.params.payload) {
 		context.params.authentication = Object.assign(context.params.authentication || {}, { payload: context.params.payload });
 	}

--- a/src/services/calendar/hooks/index.js
+++ b/src/services/calendar/hooks/index.js
@@ -33,6 +33,7 @@ const persistCourseTimesEvent = (hook) => {
 exports.before = {
 	all: [
 		authenticate('jwt'),
+		globalHooks.mapPayload,
 	],
 	find: [globalHooks.hasPermission('CALENDAR_VIEW')],
 	get: [globalHooks.hasPermission('CALENDAR_VIEW')],

--- a/src/services/fileStorage/hooks/index.js
+++ b/src/services/fileStorage/hooks/index.js
@@ -1,5 +1,5 @@
 const { authenticate } = require('@feathersjs/authentication');
-const { hasPermission, injectUserId } = require('../../../hooks');
+const { hasPermission, injectUserId, mapPayload } = require('../../../hooks');
 const resolveStorageType = require('./resolveStorageType');
 
 const resolveUserId = (hook) => {
@@ -14,6 +14,7 @@ const resolveUserId = (hook) => {
 exports.before = {
 	all: [
 		authenticate('jwt'),
+		mapPayload,
 		injectUserId,
 		resolveUserId,
 		resolveStorageType,

--- a/src/services/lesson/hooks/copy.js
+++ b/src/services/lesson/hooks/copy.js
@@ -3,7 +3,7 @@ const { Forbidden, NotFound } = require('@feathersjs/errors');
 const { disallow } = require('feathers-hooks-common');
 
 const logger = require('../../../logger/');
-const { injectUserId } = require('../../../hooks');
+const { injectUserId, mapPayload } = require('../../../hooks');
 const lesson = require('../model');
 const checkIfCourseGroupLesson = require('./checkIfCourseGroupLesson');
 const resolveStorageType = require('../../fileStorage/hooks/resolveStorageType');
@@ -39,6 +39,7 @@ exports.before = () => ({
 	find: [disallow()],
 	get: [disallow()],
 	create: [
+		mapPayload,
 		checkIfCourseGroupLesson.bind(this, 'COURSEGROUP_CREATE', 'TOPIC_CREATE', true),
 		injectUserId,
 		checkForShareToken,

--- a/src/services/notification/hooks/index.js
+++ b/src/services/notification/hooks/index.js
@@ -5,6 +5,7 @@ const globalHooks = require('../../../hooks');
 exports.before = {
 	all: [
 		authenticate('jwt'),
+		globalHooks.mapPayload,
 	],
 	find: [globalHooks.hasPermission('NOTIFICATION_VIEW')],
 	get: [globalHooks.hasPermission('NOTIFICATION_VIEW')],

--- a/src/services/wopi/hooks/index.js
+++ b/src/services/wopi/hooks/index.js
@@ -89,7 +89,7 @@ const setLockResponseHeader = (hook) => {
 };
 
 exports.before = {
-	all: [mapPayload, wopiAuthentication],
+	all: [wopiAuthentication, mapPayload],
 	find: [],
 	get: [],
 	create: [retrieveWopiOverrideHeader, checkLockHeader],

--- a/src/services/wopi/hooks/index.js
+++ b/src/services/wopi/hooks/index.js
@@ -2,6 +2,7 @@
 const { BadRequest, Conflict, NotFound } = require('@feathersjs/errors');
 const { authenticate } = require('@feathersjs/authentication');
 const { FileModel } = require('../../fileStorage/model');
+const { mapPayload } = require('../../../hooks');
 
 /**
     * handles the authentication for wopi-clients,
@@ -88,7 +89,7 @@ const setLockResponseHeader = (hook) => {
 };
 
 exports.before = {
-	all: [wopiAuthentication],
+	all: [mapPayload, wopiAuthentication],
 	find: [],
 	get: [],
 	create: [retrieveWopiOverrideHeader, checkLockHeader],

--- a/test/services/wopi/index.test.js
+++ b/test/services/wopi/index.test.js
@@ -3,8 +3,11 @@ const mockery = require('mockery');
 const app = require('../../../src/app');
 const mockAws = require('../fileStorage/aws/s3.mock');
 
+const testObjects = require('../helpers/testObjects')(app);
+const { generateRequestParamsFromUser } = require('../helpers/services/login')(app);
 
-describe('wopi service', () => {
+
+describe.only('wopi service', () => {
 	const testUserId = '599ec14d8e4e364ec18ff46d';
 
 	const testFile = {
@@ -98,54 +101,66 @@ describe('wopi service', () => {
 		}));
 	});
 
-	it('POST /wopi/files/:fileId No Action', (done) => {
-		const headers = {};
-		headers.authorization = testAccessToken;
-		app.service('wopi/files/:fileId').create({}, {
-			account: { userId: testUserId },
-			payload: testUserPayload,
-			headers,
-			fileId: testFile2._id,
-			route: { fileId: testFile2._id },
-		}).catch((e) => {
+	it('POST /wopi/files/:fileId No Action', async () => {
+		try {
+			const user = await testObjects.createTestUser();
+			const headers = {};
+			const file = await app.service('files').create({
+				owner: user._id,
+				refOwnerModel: 'user',
+				name: 'Test.docx',
+				size: 11348,
+				storageFileName: `${Date.now()}-Test.docx`,
+				permissions: [],
+			});
+			let params = await generateRequestParamsFromUser(user);
+			params = Object.assign(params, {
+				headers,
+				fileId: file._id,
+				route: { fileId: file._id },
+			});
+			headers.authorization = testAccessToken;
+			await app.service('wopi/files/:fileId').create({}, params);
+			throw new Error('schould have failed');
+		} catch (e) {
 			assert.equal(e.name, 'BadRequest');
 			assert.equal(e.message, 'X-WOPI-Override header was not provided or was empty!');
-			done();
-		});
+		}
 	});
 
-	it('POST /wopi/files/:fileId Action Lock and GetLock', (done) => { // !
+	it('POST /wopi/files/:fileId Action Lock and GetLock', async () => { // !
+		const user = await testObjects.createTestUser();
+		const file = await app.service('files').create({
+			owner: user._id,
+			refOwnerModel: 'user',
+			name: 'Test.docx',
+			size: 11348,
+			storageFileName: `${Date.now()}-Test.docx`,
+			permissions: [],
+		});
 		const headers = {};
-		headers.authorization = testAccessToken;
 		headers['x-wopi-override'] = 'LOCK';
-		const params = {
-			account: { userId: testUserId },
-			payload: testUserPayload,
+		headers.authorization = testAccessToken;
+		const authParams = await generateRequestParamsFromUser(user);
+		const firstparams = Object.assign(authParams, {
 			headers,
-			route: { fileId: testFile._id },
-			_id: testFile._id,
-		};
-		// let lockId;
+			_id: file._id,
+			route: { fileId: file._id },
+		});
 
-		app.service('wopi/files/:fileId').create({}, params)
-			.then(async (res) => {
-				const { lockId } = res;
-				assert.notEqual(lockId, undefined);
+		const { lockId } = await app.service('wopi/files/:fileId').create({}, firstparams);
+		assert.notEqual(lockId, undefined);
 
-				headers.authorization = testAccessToken;
-				headers['x-wopi-override'] = 'GET_LOCK';
-				const result = await app.service('wopi/files/:fileId').create({}, {
-					account: { userId: testUserId },
-					payload: testUserPayload,
-					headers,
-					fileId: testFile._id,
-					route: { fileId: testFile._id },
-					_id: testFile._id,
-				});
+		headers.authorization = testAccessToken;
+		headers['x-wopi-override'] = 'GET_LOCK';
+		const secondparams = Object.assign(authParams, {
+			headers,
+			_id: file._id,
+			route: { fileId: file._id },
+		});
+		const result = await app.service('wopi/files/:fileId').create({}, secondparams);
 
-				assert.equal(lockId.toString(), result.lockId.toString());
-				done();
-			});
+		assert.equal(lockId.toString(), result.lockId.toString());
 	});
 
 	it('GET /wopi/files/:fileId/contents', () => {

--- a/test/services/wopi/index.test.js
+++ b/test/services/wopi/index.test.js
@@ -7,7 +7,7 @@ const testObjects = require('../helpers/testObjects')(app);
 const { generateRequestParamsFromUser } = require('../helpers/services/login')(app);
 
 
-describe.only('wopi service', () => {
+describe('wopi service', () => {
 	const testUserId = '599ec14d8e4e364ec18ff46d';
 
 	const testFile = {


### PR DESCRIPTION
# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-2412

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt

## Datenschutz
- [x] Model- / Seedänderungen erfordern Review der Datenschutz-Gruppen (wird automatisch hinzugefügt)
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
