### PR TITLE
logger.warn -> warning

### DIFF
--- a/src/services/rocketChat/services/rocketChatChannel.js
+++ b/src/services/rocketChat/services/rocketChatChannel.js
@@ -277,7 +277,7 @@ class RocketChatChannel {
 			}
 			return Promise.resolve();
 		} catch (err) {
-			logger.warn(`Fehler beim Synchronisieren der rocket.chat moderatoren für team ${teamId} `, err);
+			logger.warning(`Fehler beim Synchronisieren der rocket.chat moderatoren für team ${teamId} `, err);
 			return Promise.reject(err);
 		}
 	}

--- a/test/services/helpers/services/classes.js
+++ b/test/services/helpers/services/classes.js
@@ -72,7 +72,7 @@ const deleteByName = (app) => async ([gradeLevel, className]) => {
 			await app.service('classes').remove(classObject._id);
 			createdClassesIds.splice(createdClassesIds.find((i) => i.toString() === classObject._id.toString()));
 		} else {
-			logger.warn(`Trying to delete a class by name that does not exist: "${gradeLevel}${className}"`);
+			logger.warning(`Trying to delete a class by name that does not exist: "${gradeLevel}${className}"`);
 		}
 	});
 	await Promise.all(promises);

--- a/test/services/user/services/AdminUsers.test.js
+++ b/test/services/user/services/AdminUsers.test.js
@@ -116,19 +116,19 @@ describe('AdminUsersService', () => {
 
 	it('sorts students correctly', async () => {
 		const teacher = await testObjects.createTestUser({ roles: ['teacher'] }).catch((err) => {
-			logger.warn('Can not create teacher', err);
+			logger.warning('Can not create teacher', err);
 		});
 		const student1 = await testObjects.createTestUser({
 			firstName: 'Max',
 			roles: ['student'],
 		}).catch((err) => {
-			logger.warn('Can not create student', err);
+			logger.warning('Can not create student', err);
 		});
 		const student2 = await testObjects.createTestUser({
 			firstName: 'Moritz',
 			roles: ['student'],
 		}).catch((err) => {
-			logger.warn('Can not create student', err);
+			logger.warning('Can not create student', err);
 		});
 
 		await testObjects.createTestConsent({


### PR DESCRIPTION
# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [ ] Links zu verwandten PRs anderer Repositories
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [ ] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-2362

## Code Qualität
- [ ] Code mit Hinblick auf Security und Datensicherheit betrachten
- [ ] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [ ] Kern-Logik ist hinter der API implementiert?

## Tests
- [ ] Test-Coverage darf durch PR nicht sinken
- [ ] Unit-Tests und Integrations-Tests schreiben / ändern
- [ ] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [ ] Feature Toggle notwendig (z.B. Environment-Variablen)
- [ ] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [ ] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [ ] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [ ] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [ ] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt

## Datenschutz
- [ ] Model- / Seedänderungen erfordern Review der Datenschutz-Gruppen (wird automatisch hinzugefügt)
- [ ] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [ ] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [ ] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
