### PR TITLE
Fix tests on Windows v2

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEFAULT_DB="schulcloud"
-DEFAULT_HOST="localhost:27017"
+DEFAULT_HOST="127.0.0.1:27017"
 DEFAULT_PATH="backup/"
 
 usage()

--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
 	"host": "localhost",
 	"port": 3030,
-	"mongodb": "mongodb://localhost:27017/schulcloud",
+	"mongodb": "mongodb://127.0.0.1:27017/schulcloud",
 	"public": "../public/",
 	"services": {
 		"calendar": "http://localhost:3000",

--- a/config/lokal.json
+++ b/config/lokal.json
@@ -1,7 +1,7 @@
 {
 	"host": "localhost",
 	"port": 3030,
-	"mongodb": "mongodb://localhost:27017/schulcloud",
+	"mongodb": "mongodb://127.0.0.1:27017/schulcloud",
 	"public": "../public/",
 	"services": {
 		"calendar": "http://localhost:3000",

--- a/config/test.json
+++ b/config/test.json
@@ -1,7 +1,7 @@
 {
 	"host": "localhost",
 	"port": 3031,
-	"mongodb": "mongodb://localhost:27017/schulcloud-test",
+	"mongodb": "mongodb://127.0.0.1:27017/schulcloud-test",
 	"public": "../public/",
 	"services": {
 		"calendar": "https://schul.tech:3000",


### PR DESCRIPTION
Changes the mongo connection string to use IPv4 to avoid DNS lookups (the MongoDB driver assumes IPv6 and tries to look up `localhost`, which takes a few seconds on Windows for some reason...). This way, the tests and `npm run seed` perform much better on Windows.