### PR TITLE
[SC-2706] Use generic first names if synced users don't have a givenName

### DIFF
--- a/src/services/ldap/strategies/general.js
+++ b/src/services/ldap/strategies/general.js
@@ -111,9 +111,20 @@ class GeneralLDAPStrategy extends AbstractLDAPStrategy {
 						return;
 					}
 
+					let firstName = obj[userAttributeNameMapping.givenName];
+					if (!firstName) {
+						if (roles.includes('administrator')) {
+							firstName = 'Admin';
+						} else if (roles.includes('teacher')) {
+							firstName = 'Lehrkraft';
+						} else {
+							firstName = 'Schüler:in';
+						}
+					}
+
 					results.push({
 						email: obj[userAttributeNameMapping.mail],
-						firstName: obj[userAttributeNameMapping.givenName],
+						firstName,
 						lastName: obj[userAttributeNameMapping.sn],
 						roles,
 						ldapDn: obj[userAttributeNameMapping.dn],

--- a/src/services/ldap/strategies/iserv.js
+++ b/src/services/ldap/strategies/iserv.js
@@ -47,15 +47,26 @@ class iServLDAPStrategy extends AbstractLDAPStrategy {
 						obj.memberOf = [obj.memberOf];
 					}
 					if (obj.memberOf.includes(this.config.providerOptions.TeacherMembershipPath)) {
+						if (!obj.givenName) {
+							obj.givenName = 'Lehrkraft';
+						}
 						roles.push('teacher');
 					}
 					if (obj.memberOf.includes(this.config.providerOptions.AdminMembershipPath)) {
+						if (!obj.givenName) {
+							obj.givenName = 'Admin';
+						}
 						roles.push('administrator');
 					}
 					if (roles.length === 0) {
-						const ignoredUser = obj.memberOf.some((item) => this.config.providerOptions.IgnoreMembershipPath.includes(item));
-						if (ignoredUser || !obj.mail || !obj.givenName || !obj.sn || !obj.uuid || !obj.uid) {
+						const ignoredUser = obj.memberOf.some(
+							(item) => this.config.providerOptions.IgnoreMembershipPath.includes(item),
+						);
+						if (ignoredUser || !obj.mail || !obj.sn || !obj.uuid || !obj.uid) {
 							return;
+						}
+						if (!obj.givenName) {
+							obj.givenName = 'Schüler:in';
 						}
 						roles.push('student');
 					}


### PR DESCRIPTION
Some schools prefer not to use first names in their iServ, so their LDAP won't give us any `givenName` for these users, which is a problem, because `user.firstName` is a required field. This PR sets some sensible defaults.

## Allgemein
- [X] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-2706

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Deployable
- [X] Feature Toggle notwendig: **nein**
- [X] Datenbankanpassungen notwendig? **nein**

## Dokumentation
- [x] Dokumentation (wenn notwendig)
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe

## Freigabe zum Review
- [X] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde
