### PR TITLE
Hotfix/20.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "schulcloud-server",
-  "version": "20.2.0",
+  "version": "20.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "20.2.0",
+	"version": "20.2.1",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/src/services/authentication/strategies/TSPStrategy.js
+++ b/src/services/authentication/strategies/TSPStrategy.js
@@ -54,10 +54,12 @@ class TSPStrategy extends AuthenticationBaseStrategy {
 		let user = await this.findUser(app, decryptedTicket);
 		if (!user) {
 			// User might have been created since the last sync
-			await app.service('sync').find({}, {
-				target: SYNCER_TARGET,
-				config: {
-					schoolIdentifier: decryptedTicket.ptscSchuleNummer,
+			await app.service('sync').find({
+				query: {
+					target: SYNCER_TARGET,
+					config: {
+						schoolIdentifier: decryptedTicket.ptscSchuleNummer,
+					},
 				},
 			});
 			user = await this.findUser(app, decryptedTicket);


### PR DESCRIPTION
Fix sync target during impromtu-sync when the user has not yet been created, but tries to login from TSP