### PR TITLE
Hotfix/22.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## [22.9.3]
 
+### Fixed 
+
+-   fixes an issue with LDAP account updates if more than one account exists for the user (migration from local login to LDAP)
+
+
+## [22.9.3]
+
 ### Fixed
 
 -   fixes regression in LDAP sync, that caused incomplete user updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "schulcloud-server",
-  "version": "22.9.3",
+  "version": "22.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "22.9.3",
+	"version": "22.9.4",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/src/services/sync/strategies/LDAPSchoolSyncer.js
+++ b/src/services/sync/strategies/LDAPSchoolSyncer.js
@@ -125,7 +125,7 @@ class LDAPSchoolSyncer extends SystemSyncer {
 		updateObject.roles = idmUser.roles;
 
 		return accountModel.update(
-			{ userId: user._id },
+			{ userId: user._id, systemId: this.system._id },
 			{ username: (`${this.school.ldapSchoolIdentifier}/${idmUser.ldapUID}`).toLowerCase() },
 		).then((_) => this.app.service('users').patch(
 			user._id,


### PR DESCRIPTION
Wenn mehrere Accounts für einen LDAP-Nutzer bestehen, zum Beispiel, weil er (im Moment per Hand, aber perspektivisch automatisch) von einem normalen zu einem LDAP-Account migriert wurde, wird jetzt nur noch der LDAP-Accoun aktualisiert und nicht der lokale Account zerstört.