### PR TITLE
Match the error message with the env variable name

### DIFF
--- a/src/services/videoconference/logic/server.js
+++ b/src/services/videoconference/logic/server.js
@@ -10,10 +10,10 @@ const SALT = Configuration.get('VIDEOCONFERENCE_SALT');
 if (FEATURE_VIDEOCONFERENCE_ENABLED === true) {
 	// host must be valid uri that does not end with an slash
 	if (!isUrl(HOST) || HOST.endsWith('/')) {
-		throw new Error('VIDEOCONFERENCE.HOST must be valid uri that does not end with a slash');
+		throw new Error('VIDEOCONFERENCE_HOST must be valid uri that does not end with a slash');
 	}
 	if (typeof SALT !== 'string' || SALT === '') {
-		throw new Error('VIDEOCONFERENCE.SALT must be a not empty string');
+		throw new Error('VIDEOCONFERENCE_SALT must be a not empty string');
 	}
 }
 


### PR DESCRIPTION
While trying to activate the big blue button integration, we noticed that the error message speaks of a different value than what needs to be [set in the environment](https://github.com/schul-cloud/schulcloud-server/compare/develop...bitcrowd:fix-error-message?expand=1#diff-c0b437d8676620274b8f1c805f65b172L6).

# Checkliste

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-client/pull/????
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-????

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt
  - [x] Changelog-Eintrag

## Datenschutz
- [x] Model- / Seedänderungen erfordern Review der Datenschutz-Gruppen (wird automatisch hinzugefügt)
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
