### PR TITLE
fix backup.js export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 -   SC-3892 Update Filter of submission in order to work with older submissions
 -   SC-3395 if fetching the release fails, a error will be thrown
+-   backup.js now outputs valid json exports
 
 ### Changed
 

--- a/backup.js
+++ b/backup.js
@@ -208,6 +208,7 @@ const exportCollection = async ({
 		...CONFIG.MONGO.CREDENTIALS_ARGS,
 		'--collection', collection,
 		'--out', filePath,
+		'--jsonArray',
 		args['--pretty'] ? '--pretty' : undefined,
 	];
 	const res = await asyncExec(cleanJoin(cmdArgs));


### PR DESCRIPTION
fixes a bug, that all exports haven't containes `,` as delimiters