### PR TITLE
Move "chai" packages to "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,6 @@
 		"bbb-promise": "^1.2.0",
 		"bcryptjs": "latest",
 		"body-parser": "^1.15.2",
-		"chai": "^4.2.0",
-		"chai-as-promised": "^7.1.1",
-		"chai-http": "^4.2.0",
 		"chalk": "^3.0.0",
 		"chance": "^1.0.12",
 		"client-oauth2": "^4.2.5",
@@ -107,6 +104,9 @@
 		"xml2js-es6-promise": "^1.1.1"
 	},
 	"devDependencies": {
+		"chai": "^4.2.0",
+		"chai-as-promised": "^7.1.1",
+		"chai-http": "^4.2.0",
 		"codecov": "^3.6.5",
 		"eslint-config-airbnb-base": "^14.1.0",
 		"eslint-plugin-import": "^2.18.2",


### PR DESCRIPTION
As far as I can see we only use [Chai](https://www.chaijs.com/) for testing.

> Please do not put test harnesses or transpilers in your dependencies object. See devDependencies, below.

— https://docs.npmjs.com/files/package.json#dependencies