### PR TITLE
fix user tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 -   SC-3892 Update Filter of submission in order to work with older submissions
 -   SC-3395 if fetching the release fails, a error will be thrown
 -   backup.js now outputs valid json exports
+-   SC-4105 fixed a problem with new users tests not working with recent hotfix.
 
 ### Changed
 

--- a/test/services/user/services/userService.test.js
+++ b/test/services/user/services/userService.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { expect } = require('chai');
+const { Configuration } = require('@schul-cloud/commons');
 const app = require('../../../../src/app');
 
 const userService = app.service('users');
@@ -103,6 +104,7 @@ describe('user service', () => {
 		const actingUser = await testObjects.createTestUser({ roles: ['notAuthorized'] });
 		const params = await testObjects.generateRequestParamsFromUser(actingUser);
 		params.query = {};
+		params.headers = { 'x-api-key': Configuration.get('CLIENT_API_KEY') }; // toDO remove with SC-4112
 		try {
 			await app.service('users').remove(studentToDelete._id, params);
 			throw new Error('should have failed');
@@ -121,6 +123,7 @@ describe('user service', () => {
 		const actingUser = await testObjects.createTestUser({ roles: ['studentDelete'] });
 		const params = await testObjects.generateRequestParamsFromUser(actingUser);
 		params.query = {};
+		params.headers = { 'x-api-key': Configuration.get('CLIENT_API_KEY') }; // toDO remove with SC-4112
 		try {
 			const result = await app.service('users').remove(studentToDelete._id, params);
 			expect(result).to.not.be.undefined;
@@ -138,6 +141,7 @@ describe('user service', () => {
 		const actingUser = await testObjects.createTestUser({ roles: ['notAuthorized'] });
 		const params = await testObjects.generateRequestParamsFromUser(actingUser);
 		params.query = {};
+		params.headers = { 'x-api-key': Configuration.get('CLIENT_API_KEY') }; // toDO remove with SC-4112
 		try {
 			await app.service('users').remove(studentToDelete._id, params);
 			throw new Error('should have failed');
@@ -156,6 +160,7 @@ describe('user service', () => {
 		const actingUser = await testObjects.createTestUser({ roles: ['teacherDelete'] });
 		const params = await testObjects.generateRequestParamsFromUser(actingUser);
 		params.query = {};
+		params.headers = { 'x-api-key': Configuration.get('CLIENT_API_KEY') }; // toDO remove with SC-4112
 		try {
 			const result = await app.service('users').remove(studentToDelete._id, params);
 			expect(result).to.not.be.undefined;
@@ -179,6 +184,7 @@ describe('user service', () => {
 			const actingUser = await testObjects.createTestUser({ roles: ['studentDelete'] });
 			const params = await testObjects.generateRequestParamsFromUser(actingUser);
 			params.query = { _id: { $in: userIds } };
+			params.headers = { 'x-api-key': Configuration.get('CLIENT_API_KEY') }; // toDO remove with SC-4112
 			let result;
 			try {
 				result = await app.service('users').remove(null, params);
@@ -203,6 +209,7 @@ describe('user service', () => {
 			const actingUser = await testObjects.createTestUser({ roles: ['studentDelete'] });
 			const params = await testObjects.generateRequestParamsFromUser(actingUser);
 			params.query = { _id: { $in: userIds } };
+			params.headers = { 'x-api-key': Configuration.get('CLIENT_API_KEY') }; // toDO remove with SC-4112
 			let result;
 			try {
 				result = await app.service('users').remove(null, params);


### PR DESCRIPTION
# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-4105

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Swagger
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt
  - [x] Changelog-Eintrag

## Datenschutz
- [x] Model- / Seedänderungen erfordern Review der Datenschutz-Gruppen (wird automatisch hinzugefügt)
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
