### PR TITLE
[#SC-4064-3] Change download file names (3/4)

### DIFF
--- a/src/services/fileStorage/proxy-service.js
+++ b/src/services/fileStorage/proxy-service.js
@@ -434,7 +434,7 @@ const signedUrlService = {
 			.then(() => strategy.getSignedUrl({
 				userId: creatorId,
 				flatFileName: fileObject.storageFileName,
-				localFileName: fileObject.name,
+				localFileName: query.name || fileObject.name,
 				download,
 			}))
 			.then((res) => ({

--- a/test/services/fileStorage/index.test.js
+++ b/test/services/fileStorage/index.test.js
@@ -411,20 +411,18 @@ describe('fileStorage services', () => {
 			const requestedName = encodeURIComponent('some name-12345678id.png');
 			const spy = sinon.spy(AWSStrategy.prototype, 'getSignedUrl');
 
-			await signedUrlService
-				.find({
+			try {
+				await signedUrlService.find({
 					query: {
 						file: '5ca613c4c7f5120b8c5bef33',
 						name: requestedName,
 					},
 					...context,
-				})
-				.then(() => {
-					expect(spy.calledWithMatch({ localFileName: requestedName })).to.equal(true);
-				})
-				.finally(() => {
-					spy.restore();
 				});
+				expect(spy.calledWithMatch({ localFileName: requestedName })).to.equal(true);
+			} finally {
+				spy.restore();
+			}
 		});
 	});
 

--- a/test/services/fileStorage/index.test.js
+++ b/test/services/fileStorage/index.test.js
@@ -2,6 +2,7 @@ const mockery = require('mockery');
 const { expect } = require('chai');
 const assert = require('assert');
 const mongoose = require('mongoose');
+const sinon = require('sinon');
 
 const fixtures = require('./fixtures');
 
@@ -403,6 +404,27 @@ describe('fileStorage services', () => {
 			}));
 
 			return Promise.all(promises);
+		});
+
+		it('allows to override the internal file name with a request specific one', async () => {
+			const context = setContext('0000d224816abba584714c8e');
+			const requestedName = encodeURIComponent('some name-12345678id.png');
+			const spy = sinon.spy(AWSStrategy.prototype, 'getSignedUrl');
+
+			await signedUrlService
+				.find({
+					query: {
+						file: '5ca613c4c7f5120b8c5bef33',
+						name: requestedName,
+					},
+					...context,
+				})
+				.then(() => {
+					expect(spy.calledWithMatch({ localFileName: requestedName })).to.equal(true);
+				})
+				.finally(() => {
+					spy.restore();
+				});
 		});
 	});
 


### PR DESCRIPTION
# Description

When generating a signed URL for downloading a file, accept the `name` query argument so that the client can name download files.

This allows us to rename files that students handed in as homework submission so that they can be downloaded by the teacher, graded, and then re-uploaded in bulk, with an automatic assignment to the proper student/team.

## Links to Tickets or other pull requests
[Story](https://ticketsystem.schul-cloud.org/browse/SC-4064) (Part 3, in preparation for 4)
Allow the client to change the file names of requested files

## Changes
- Prioritize query names over saved names when setting the download file name in signed fetch URLs.
- Add what seems to be the first test using `sinon`.

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

No change in permissions, or models.

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
