### PR TITLE
gitflow-feature-stash: enhance-bbb-errors

### DIFF
--- a/src/services/videoconference/logic/index.js
+++ b/src/services/videoconference/logic/index.js
@@ -79,5 +79,6 @@ exports.getMeetingInfo = (server, meetingId) => server.monitoring
 			// valid response with not found or existing meeting
 			return response;
 		}
+		error('unknown bbb response', meeting);
 		throw new Error('unknown response from bbb...');
 	});


### PR DESCRIPTION
just log the error for debugging reasons. this allows to get error messages like checksum error (for wrong salt) into the log