### PR TITLE
SC-4957 add ldap indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed
 
+- SC-4957 user.ldapId and user.ldapDn are now indexed to improve performance
+
 ### Security
 
 ### Removed

--- a/backup/setup/migrations.json
+++ b/backup/setup/migrations.json
@@ -607,5 +607,15 @@
 		"$date": "2020-06-04T13:10:39.414Z"
 	},
 	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "5edf56430383be55fc9a8ee3"
+	},
+	"state": "up",
+	"name": "updateUserIndexesForLDAP",
+	"createdAt": {
+		"$date": "2020-06-09T09:28:35.874Z"
+	},
+	"__v": 0
 }]
-

--- a/migrations/1591694915874-updateUserIndexesForLDAP.js
+++ b/migrations/1591694915874-updateUserIndexesForLDAP.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+
+const { connect, close } = require('../src/utils/database');
+
+const { userSchema } = require('../src/services/user/model/user.schema');
+
+const User = mongoose.model('user87324782376247457621', userSchema, 'user');
+
+module.exports = {
+	up: async function up() {
+		await connect();
+		// ////////////////////////////////////////////////////
+		await User.syncIndexes();
+		// ////////////////////////////////////////////////////
+		await close();
+	},
+
+	down: async function down() {
+		await connect();
+		// ////////////////////////////////////////////////////
+		await User.syncIndexes();
+		// ////////////////////////////////////////////////////
+		await close();
+	},
+};

--- a/src/services/user/model/user.schema.js
+++ b/src/services/user/model/user.schema.js
@@ -51,8 +51,9 @@ const userSchema = new Schema({
 	*/
 	discoverable: { type: Boolean, required: false },
 
-	ldapDn: { type: String },
-	ldapId: { type: String },
+	// optional attributes if user was created during LDAP sync:
+	ldapDn: { type: String, index: true }, // LDAP login username
+	ldapId: { type: String, index: true }, // UUID to identify during the sync
 
 	...externalSourceSchema,
 


### PR DESCRIPTION
# Description

- adds indexes on user.ldapId and user.ldapDn to speed up LDAP login and sync

## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-4957

## Deployment

- includes a migration to sync the indexes

## Approval for review
- [X] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.