### PR TITLE
Hotfix/23.4.5 fix ldap self service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Removed
 
+## [23.4.5] - 2020-06-17
+
+### Fixed in 23.4.5
+
+- SC-5007 re-introduces ldap system root path to API result to fix issue with duplicating schools
+
+
 ## [23.4.3-nbc] - 2020-06-15
 
 ### Fixed in 23.4.3-nbc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "23.4.4",
+	"version": "23.4.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "23.4.4",
+	"version": "23.4.5",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/src/services/school/hooks/index.js
+++ b/src/services/school/hooks/index.js
@@ -229,7 +229,8 @@ exports.before = {
 
 exports.after = {
 	all: [
-		iff(populateInQuery, keepInArray('systems', ['_id', 'type', 'alias', 'ldapConfig.active'])),
+		iff(populateInQuery,
+			keepInArray('systems', ['_id', 'type', 'alias', 'ldapConfig.active', 'ldapConfig.rootPath'])),
 		iff(isProvider('external') && !globalHooks.isSuperHero(), discard('storageProvider')),
 	],
 	find: [decorateYears, setStudentsCanCreateTeams],


### PR DESCRIPTION
Re-introduces the LDAP root path to allowed attributes in API response to fix duplicating schools via LDAP self-service

Ticket: https://ticketsystem.schul-cloud.org/browse/SC-5007